### PR TITLE
Add an implementation of GCMC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ tests:
 	python3 testsuite/read-write-df_test.py
 	python3 testsuite/henderson_hasselbalch_tests.py
 	python3 testsuite/cph_ideal_tests.py
+	python3 testsuite/gcmc_tests.py
 	python3 testsuite/grxmc_ideal_tests.py
 	python3 testsuite/peptide_tests.py
+	python3 testsuite/gcmc_tests.py --mode interacting
 	python3 testsuite/weak_polyelectrolyte_dialysis_test.py
 	python3 testsuite/globular_protein_tests.py
 sample:

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,9 @@ tests:
 	python3 testsuite/read-write-df_test.py
 	python3 testsuite/henderson_hasselbalch_tests.py
 	python3 testsuite/cph_ideal_tests.py
-	python3 testsuite/gcmc_tests.py
 	python3 testsuite/grxmc_ideal_tests.py
 	python3 testsuite/peptide_tests.py
-	python3 testsuite/gcmc_tests.py --mode interacting
+	python3 testsuite/gcmc_tests.py
 	python3 testsuite/weak_polyelectrolyte_dialysis_test.py
 	python3 testsuite/globular_protein_tests.py
 sample:

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -55,7 +55,9 @@ parser.add_argument('--output',
                     type=str,
                     required= False,
                     help='output directory')
-parser.add_argument('--no_verbose', action='store_false', help="Switch to deactivate verbose")
+parser.add_argument('--no_verbose', 
+                    action='store_false', 
+                    help="Switch to deactivate verbose")
 args = parser.parse_args()
 
 # Inputs

--- a/samples/salt_solution_gcmc.py
+++ b/samples/salt_solution_gcmc.py
@@ -1,0 +1,195 @@
+# Load python modules
+import sys
+import os 
+import inspect
+from matplotlib.style import use
+import espressomd
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+from scipy import interpolate
+import argparse
+from tqdm import tqdm
+from espressomd.io.writer import vtf
+from espressomd import interactions
+from espressomd import electrostatics
+
+# Import pyMBE
+import pyMBE
+from lib import analysis
+
+# Create an instance of pyMBE library
+pmb = pyMBE.pymbe_library()
+
+import warnings
+
+
+# Command line arguments
+parser = argparse.ArgumentParser(description='Script that runs a simulation of a salt solution in the grand-canonical ensemble using pyMBE and ESPResSo.')
+parser.add_argument("--c_salt_res", 
+                    type=float, 
+                    help="Concentration of salt in the reservoir in mol/l.")
+parser.add_argument('--mode',
+                    type=str,
+                    default= "ideal",
+                    help='Set if an ideal or interacting system is simulated.')
+parser.add_argument('--output',
+                    type=str,
+                    required= False,
+                    help='output directory')
+parser.add_argument('--no_verbose', 
+                    action='store_false', 
+                    help="Switch to deactivate verbose")
+args = parser.parse_args()
+
+# Inputs
+inputs={"csalt": args.c_salt_res,
+        "mode": args.mode}
+
+mode=args.mode
+valid_modes=["ideal", "interacting"]
+verbose=args.no_verbose
+
+if args.mode not in valid_modes:
+    raise ValueError(f"Mode {mode} is not currently supported, valid modes are {valid_modes}")
+
+#Import functions from handy_functions script 
+from lib.handy_functions import minimize_espresso_system_energy
+from lib.analysis import block_analyze
+from lib.handy_functions import setup_electrostatic_interactions
+from lib.handy_functions import setup_langevin_dynamics
+
+
+
+# Units and general parameters
+pmb.set_reduced_units(unit_length=0.355*pmb.units.nm)
+solvent_permittivity = 78.9
+
+# Integration parameters
+DT = 0.01
+LANGEVIN_SEED = 42
+REACTION_SEED = 42
+
+# Define salt
+cation_name = 'Na'
+anion_name = 'Cl'
+pmb.define_particle(name=cation_name, q=1, sigma=0.355*pmb.units.nm, epsilon=1*pmb.units('reduced_energy'))
+pmb.define_particle(name=anion_name,  q=-1, sigma=0.355*pmb.units.nm,  epsilon=1*pmb.units('reduced_energy'))
+
+# System parameters
+c_salt_res = args.c_salt_res * pmb.units.mol/ pmb.units.L
+N_SALT_ION_PAIRS = 200
+volume = N_SALT_ION_PAIRS/(pmb.N_A*c_salt_res)
+L = volume ** (1./3.) # Side of the simulation box
+
+# Create an instance of an espresso system
+espresso_system=espressomd.System (box_l = [L.to('reduced_length').magnitude]*3)
+if verbose:
+    print("Created espresso object")
+
+# Add salt
+c_salt_calculated = pmb.create_added_salt(espresso_system=espresso_system,cation_name=cation_name,anion_name=anion_name,c_salt=0.5*c_salt_res)
+if verbose:
+    print("Added salt")
+
+# Set up reactions
+if args.mode == "interacting":
+    path_to_ex_pot=pmb.get_resource("testsuite/data/src/")
+    ionic_strength, excess_chemical_potential_monovalent_pairs_in_bulk_data, bjerrums, excess_chemical_potential_monovalent_pairs_in_bulk_data_error =np.loadtxt(f"{path_to_ex_pot}/excess_chemical_potential.dat", unpack=True)
+    excess_chemical_potential_monovalent_pair_interpolated = interpolate.interp1d(ionic_strength, excess_chemical_potential_monovalent_pairs_in_bulk_data)
+    activity_coefficient_monovalent_pair = lambda x: np.exp(excess_chemical_potential_monovalent_pair_interpolated(x.to('1/(reduced_length**3 * N_A)').magnitude))
+    RE = pmb.setup_gcmc(c_salt_res=c_salt_res, salt_cation_name=cation_name, salt_anion_name=anion_name, SEED=REACTION_SEED, activity_coefficient=activity_coefficient_monovalent_pair)
+elif args.mode == "ideal":
+    RE = pmb.setup_gcmc(c_salt_res=c_salt_res, salt_cation_name=cation_name, salt_anion_name=anion_name, SEED=REACTION_SEED)
+if verbose:
+    print("Set up GCMC...")
+
+# Setup espresso to track the ionization of the acid/basic groups in peptide
+type_map = pmb.get_type_map()
+types = list (type_map.values())
+espresso_system.setup_type_map(type_list = types)
+print(type_map)
+
+# Setup the non-interacting type for speeding up the sampling of the reactions
+non_interacting_type = max(type_map.values())+1
+RE.set_non_interacting_type(type=non_interacting_type)
+print('The non interacting type is set to ', non_interacting_type)
+
+espresso_system.time_step = DT
+
+if args.mode == "interacting":
+    #Set up the short-range interactions
+    pmb.setup_lj_interactions(espresso_system=espresso_system)
+
+# Minimzation
+minimize_espresso_system_energy(espresso_system=espresso_system, Nsteps=1e4, max_displacement=0.01, skin=0.4)
+setup_langevin_dynamics(espresso_system=espresso_system, 
+                                    kT = pmb.kT, 
+                                    SEED = LANGEVIN_SEED,
+                                    time_step=DT,
+                                    tune_skin=False)
+
+if verbose:
+    print("Running warmup without electrostatics")
+for i in tqdm(range(100),disable=not verbose):
+    espresso_system.integrator.run(steps=100)
+    RE.reaction(reaction_steps=100)
+
+if args.mode == "interacting":
+    setup_electrostatic_interactions(units=pmb.units,
+                                    espresso_system=espresso_system,
+                                    kT=pmb.kT,
+                                    solvent_permittivity=solvent_permittivity)
+
+espresso_system.thermostat.turn_off()
+minimize_espresso_system_energy(espresso_system=espresso_system, Nsteps=1e4, max_displacement=0.01, skin=0.4)
+setup_langevin_dynamics(espresso_system=espresso_system, 
+                                    kT = pmb.kT, 
+                                    SEED = LANGEVIN_SEED,
+                                    time_step=DT,
+                                    tune_skin=False)
+
+if verbose:
+    print("Running warmup with electrostatics")
+
+N_warmup_loops = 100
+for i in tqdm(range(N_warmup_loops),disable=not verbose):
+    espresso_system.integrator.run(steps=100)
+    RE.reaction(reaction_steps=100)
+
+# Main loop
+print("Started production run.")
+
+labels_obs=["time", "c_salt"]
+time_series={}
+
+for label in labels_obs:
+    time_series[label]=[]
+
+N_production_loops = 100
+for i in tqdm(range(N_production_loops),disable=not verbose):
+    espresso_system.integrator.run(steps=100)
+    RE.reaction(reaction_steps=100)
+
+    # Measure time
+    time_series["time"].append(espresso_system.time)
+
+    # Measure degree of ionization
+    number_of_ion_pairs = espresso_system.number_of_particles(type_map[cation_name])
+    time_series["c_salt"].append((number_of_ion_pairs/(volume * pmb.N_A)).magnitude)
+
+data_path = args.output
+if data_path is None:
+    data_path=pmb.get_resource(path="samples/Beyer2024")+"/time_series/gcmc"
+
+if not os.path.exists(data_path):
+    os.makedirs(data_path)
+
+time_series=pd.DataFrame(time_series)
+filename=analysis.built_output_name(input_dict=inputs)
+
+time_series.to_csv(f"{data_path}/{filename}_time_series.csv", index=False)
+particle_id_list = pmb.df.loc[~pmb.df['molecule_id'].isna()].particle_id.dropna().to_list()
+
+#Save the pyMBE dataframe in a CSV file
+pmb.write_pmb_df(filename='df.csv')

--- a/testsuite/gcmc_tests.py
+++ b/testsuite/gcmc_tests.py
@@ -8,16 +8,30 @@ import numpy as np
 import pandas as pd
 import argparse
 
+# Template of the test
+
+def gcmc_test(mode):
+    if mode == "ideal":
+        print(f"*** Running test for GCMC of salt solution (ideal). ***")
+    elif mode == "interacting":
+        print(f"*** Running test for GCMC of salt solution (interacting). ***")
+    with tempfile.TemporaryDirectory() as time_series_path:
+        for c_salt_res in salt_concentrations:
+            print(f"c_salt_res = {c_salt_res}")
+            run_command=["python3", script_path, "--c_salt_res", str(c_salt_res), "--output", time_series_path, "--mode", mode, "--no_verbose"]
+            print(subprocess.list2cmdline(run_command))
+            subprocess.check_output(run_command)
+        # Analyze all time series
+        data=analysis.analyze_time_series(path_to_datafolder=time_series_path)
+
+    # Check concentration
+    test_concentration=np.sort(data["csalt","value"].to_numpy(dtype=float))
+    ref_concentration=np.sort(data["mean","c_salt"].to_numpy())
+    np.testing.assert_allclose(test_concentration, ref_concentration, rtol=rtol, atol=atol)
+    print(f"*** Test was successful ***")
+
 # Create an instance of pyMBE library
 pmb = pyMBE.pymbe_library()
-
-# Command line arguments
-parser = argparse.ArgumentParser(description='Test of the GCMC implementation in pyMBE.')
-parser.add_argument('--mode',
-                    type=str,
-                    default= "ideal",
-                    help='Set if an ideal or interacting system is simulated.')
-args = parser.parse_args()
 
 script_path=pmb.get_resource(f"samples/salt_solution_gcmc.py")
 salt_concentrations=[0.0001, 0.001, 0.01, 0.1]
@@ -25,21 +39,8 @@ salt_concentrations=[0.0001, 0.001, 0.01, 0.1]
 rtol=0.05 # relative tolerance
 atol=0.0 # absolute tolerance
 
-if args.mode == "ideal":
-    print(f"*** Running test for GCMC of salt solution (ideal). ***")
-elif args.mode == "interacting":
-    print(f"*** Running test for GCMC of salt solution (interacting). ***")
-with tempfile.TemporaryDirectory() as time_series_path:
-    for c_salt_res in salt_concentrations:
-        print(f"c_salt_res = {c_salt_res}")
-        run_command=["python3", script_path, "--c_salt_res", str(c_salt_res), "--mode", "ideal", "--output", time_series_path, "--mode", args.mode, "--no_verbose"]
-        print(subprocess.list2cmdline(run_command))
-        subprocess.check_output(run_command)
-    # Analyze all time series
-    data=analysis.analyze_time_series(path_to_datafolder=time_series_path)
+# Ideal test
+gcmc_test("ideal")
 
-# Check concentration
-test_concentration=np.sort(data["csalt","value"].to_numpy(dtype=float))
-ref_concentration=np.sort(data["mean","c_salt"].to_numpy())
-np.testing.assert_allclose(test_concentration, ref_concentration, rtol=rtol, atol=atol)
-print(f"*** Test was successful ***")
+# Interacting test
+gcmc_test("interacting")

--- a/testsuite/gcmc_tests.py
+++ b/testsuite/gcmc_tests.py
@@ -1,0 +1,45 @@
+# Import pyMBE and other libraries
+import pyMBE
+from lib import analysis
+import os
+import tempfile
+import subprocess
+import numpy as np
+import pandas as pd
+import argparse
+
+# Create an instance of pyMBE library
+pmb = pyMBE.pymbe_library()
+
+# Command line arguments
+parser = argparse.ArgumentParser(description='Test of the GCMC implementation in pyMBE.')
+parser.add_argument('--mode',
+                    type=str,
+                    default= "ideal",
+                    help='Set if an ideal or interacting system is simulated.')
+args = parser.parse_args()
+
+script_path=pmb.get_resource(f"samples/salt_solution_gcmc.py")
+salt_concentrations=[0.0001, 0.001, 0.01, 0.1]
+
+rtol=0.05 # relative tolerance
+atol=0.0 # absolute tolerance
+
+if args.mode == "ideal":
+    print(f"*** Running test for GCMC of salt solution (ideal). ***")
+elif args.mode == "interacting":
+    print(f"*** Running test for GCMC of salt solution (interacting). ***")
+with tempfile.TemporaryDirectory() as time_series_path:
+    for c_salt_res in salt_concentrations:
+        print(f"c_salt_res = {c_salt_res}")
+        run_command=["python3", script_path, "--c_salt_res", str(c_salt_res), "--mode", "ideal", "--output", time_series_path, "--mode", args.mode, "--no_verbose"]
+        print(subprocess.list2cmdline(run_command))
+        subprocess.check_output(run_command)
+    # Analyze all time series
+    data=analysis.analyze_time_series(path_to_datafolder=time_series_path)
+
+# Check concentration
+test_concentration=np.sort(data["csalt","value"].to_numpy(dtype=float))
+ref_concentration=np.sort(data["mean","c_salt"].to_numpy())
+np.testing.assert_allclose(test_concentration, ref_concentration, rtol=rtol, atol=atol)
+print(f"*** Test was successful ***")


### PR DESCRIPTION
Solves #37 

@pm-blanco I have added a function `setup_gcmc` that allows for setting up simulations where the system is coupled grand-canonically to a reservoir at a given salt concentration. The design of the function is similar to the setup of the grand-reaction method; optionally one can provide again a function that calculates the activity coefficient in order to correctly set up the method in the case of an interacting system. 

A minimal example is provided in `samples/salt_solution_gcmc.py`; this script is also used in two tests I added to the testsuite, one of them for an ideal system and the other one for an interacting system. Both of these tests check if the GCMC implementation leads to the expected (input) concentration of salt.