### PR TITLE
Make the seed a global variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ tests:
 	python3 testsuite/bond_tests.py
 	python3 testsuite/generate_perpendicular_vectors_test.py
 	python3 testsuite/create_molecule_position_test.py
+	python3 testsuite/seed_test.py
 	python3 testsuite/read-write-df_test.py
 	python3 testsuite/henderson_hasselbalch_tests.py
 	python3 testsuite/cph_ideal_tests.py

--- a/maintainer/standarize_data.py
+++ b/maintainer/standarize_data.py
@@ -5,7 +5,7 @@ import pandas as pd
 import argparse 
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 # Expected inputs
 supported_filenames=["data_landsgesell.csv",

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -204,10 +204,10 @@ class pymbe_library():
     
     def calculate_center_of_mass_of_molecule(self, molecule_id, espresso_system):
         """
-        Calculates the center of mass of type `name`.
+        Calculates the center of the molecule with a given molecule_id.
 
         Args:
-            molecule_id(`int`): Id of the molecule to be centered.
+            molecule_id(`int`): Id of the molecule whose center of mass is to be calculated.
             espresso_system(`obj`): Instance of a system object from the espressomd library.
         
         Returns:
@@ -295,7 +295,7 @@ class pymbe_library():
         Calculates the charge on the different molecules according to the Henderson-Hasselbalch equation coupled to the Donnan partitioning.
 
         Args:
-            c_macro ('dic'): {"name": concentration} - A dict containing the concentrations of all charged macromolecular species in the system. 
+            c_macro ('dict'): {"name": concentration} - A dict containing the concentrations of all charged macromolecular species in the system. 
             c_salt ('float'): Salt concentration in the reservoir.
             pH_list ('lst'): List of pH-values in the reservoir. 
             pka_set ('dict'): {"name": {"pka_value": pka, "acidity": acidity}}.
@@ -455,17 +455,14 @@ class pymbe_library():
             molecule_id(`int`): Id of the molecule to be centered.
             espresso_system(`obj`): Instance of a system object from the espressomd library.
         """
-        center_of_mass = self.calculate_center_of_mass_of_molecule ( molecule_id=molecule_id,espresso_system=espresso_system)
+        center_of_mass = self.calculate_center_of_mass_of_molecule(molecule_id=molecule_id,espresso_system=espresso_system)
         box_center = [espresso_system.box_l[0]/2.0,
                       espresso_system.box_l[1]/2.0,
                       espresso_system.box_l[2]/2.0]
-        pmb_type = self.df.loc[self.df['molecule_id']==molecule_id].pmb_type.values[0]
-        pmb_objects = ['protein','molecule','peptide']
-        if pmb_type in pmb_objects:
-            particle_id_list = self.df.loc[self.df['molecule_id']==molecule_id].particle_id.dropna().to_list()
-            for pid in particle_id_list:
-                es_pos = espresso_system.part.by_id(pid).pos
-                espresso_system.part.by_id(pid).pos = es_pos - center_of_mass + box_center
+        particle_id_list = self.df.loc[self.df['molecule_id']==molecule_id].particle_id.dropna().to_list()
+        for pid in particle_id_list:
+            es_pos = espresso_system.part.by_id(pid).pos
+            espresso_system.part.by_id(pid).pos = es_pos - center_of_mass + box_center
         return 
 
     def check_dimensionality(self, variable, expected_dimensionality):
@@ -802,112 +799,114 @@ class pymbe_library():
         return counterion_number
         
     def create_molecule(self, name, number_of_molecules, espresso_system, list_of_first_residue_positions=None, use_default_bond=False):
-            """
-            Creates `number_of_molecules` molecule of type `name` into `espresso_system` and bookkeeps them into `pmb.df`.
+        """
+        Creates `number_of_molecules` molecule of type `name` into `espresso_system` and bookkeeps them into `pmb.df`.
 
-            Args:
-                name(`str`): Label of the molecule type to be created. `name` must be defined in `pmb.df`
-                espresso_system(`obj`): Instance of a system object from espressomd library.
-                number_of_molecules(`int`): Number of molecules of type `name` to be created.
-                list_of_first_residue_positions(`list`, optional): List of coordinates where the central bead of the first_residue_position will be created, random by default
-                use_default_bond(`bool`, optional): Controls if a bond of type `default` is used to bond particle with undefined bonds in `pymbe.df`
-            Returns:
-                molecules_info (`dict`):  {molecule_id: {residue_id:{"central_bead_id":central_bead_id, "side_chain_ids": [particle_id1, ...]}}} 
-            """
-            if list_of_first_residue_positions != None:
-                for item in list_of_first_residue_positions:
-                    if isinstance(item, list) == False:
-                        raise ValueError(f"The provided input position is not a nested list. Should be a nested list with elements of 3D lists, corresponding to xyz coord.")
-                    elif len(item) != 3:
-                        raise ValueError(f"The provided input position is formatted wrong. The elements in the provided list does not have 3 coordinates, corresponding to xyz coord.")
+        Args:
+            name(`str`): Label of the molecule type to be created. `name` must be defined in `pmb.df`
+            espresso_system(`obj`): Instance of a system object from espressomd library.
+            number_of_molecules(`int`): Number of molecules of type `name` to be created.
+            list_of_first_residue_positions(`list`, optional): List of coordinates where the central bead of the first_residue_position will be created, random by default
+            use_default_bond(`bool`, optional): Controls if a bond of type `default` is used to bond particle with undefined bonds in `pymbe.df`
+        Returns:
 
-                if len(list_of_first_residue_positions) != number_of_molecules:
-                                raise ValueError(f"Number of positions provided in {list_of_first_residue_positions} does not match number of molecules desired, {number_of_molecules}")
-            if number_of_molecules <= 0:
-                return
-            if not self.check_if_name_is_defined_in_df(name=name,
-                                                        pmb_type_to_be_defined='molecule'):
-                raise ValueError(f"{name} must correspond to a label of a pmb_type='molecule' defined on df")
-            first_residue = True
-            molecule_info = []
-            residue_list = self.df[self.df['name']==name].residue_list.values [0]
+            molecules_info (`dict`):  {molecule_id: {residue_id:{"central_bead_id":central_bead_id, "side_chain_ids": [particle_id1, ...]}}} 
+        """
+        if list_of_first_residue_positions != None:
+            for item in list_of_first_residue_positions:
+                if isinstance(item, list) == False:
+                    raise ValueError(f"The provided input position is not a nested list. Should be a nested list with elements of 3D lists, corresponding to xyz coord.")
+                elif len(item) != 3:
+                    raise ValueError(f"The provided input position is formatted wrong. The elements in the provided list does not have 3 coordinates, corresponding to xyz coord.")
 
-            self.copy_df_entry(name=name,
-                            column_name='molecule_id',
-                            number_of_copies=number_of_molecules)
-            
-            molecules_index = self.np.where(self.df['name']==name)
-            molecule_index_list =list(molecules_index[0])[-number_of_molecules:]
-            used_molecules_id = self.df.molecule_id.dropna().drop_duplicates().tolist()
-            pos_index = 0 
-            for molecule_index in molecule_index_list:        
-                molecule_id = self.assign_molecule_id (name=name,pmb_type='molecule',used_molecules_id=used_molecules_id,molecule_index=molecule_index)
-                for residue in residue_list:
-                    if first_residue:
-                        if list_of_first_residue_positions == None:
-                            residue_position = None
-                        else:
-                            for item in list_of_first_residue_positions:
-                                residue_position = [self.np.array(list_of_first_residue_positions[pos_index])]
-                        # Generate an arbitrary random unit vector
-                        backbone_vector = self.generate_random_points_in_a_sphere(center=[0,0,0], 
-                                                                    radius=1, 
-                                                                    n_samples=1,
-                                                                    on_surface=True)[0]
-                        residues_info = self.create_residue(name=residue,
-                                                            number_of_residues=1, 
-                                                            espresso_system=espresso_system, 
-                                                            central_bead_position=residue_position,  
-                                                            use_default_bond= use_default_bond, 
-                                                            backbone_vector=backbone_vector)
-                        residue_id = next(iter(residues_info))
-                        for index in self.df[self.df['residue_id']==residue_id].index:
+            if len(list_of_first_residue_positions) != number_of_molecules:
+                            raise ValueError(f"Number of positions provided in {list_of_first_residue_positions} does not match number of molecules desired, {number_of_molecules}")
+        if number_of_molecules <= 0:
+            return
+        if not self.check_if_name_is_defined_in_df(name=name,
+                                                    pmb_type_to_be_defined='molecule'):
+            raise ValueError(f"{name} must correspond to a label of a pmb_type='molecule' defined on df")
+        first_residue = True
+        molecules_info = {}
+        residue_list = self.df[self.df['name']==name].residue_list.values [0]
+
+        self.copy_df_entry(name=name,
+                        column_name='molecule_id',
+                        number_of_copies=number_of_molecules)
+        
+        molecules_index = self.np.where(self.df['name']==name)
+        molecule_index_list =list(molecules_index[0])[-number_of_molecules:]
+        used_molecules_id = self.df.molecule_id.dropna().drop_duplicates().tolist()
+        pos_index = 0 
+        for molecule_index in molecule_index_list:        
+            molecule_id = self.assign_molecule_id(name=name,pmb_type='molecule',used_molecules_id=used_molecules_id,molecule_index=molecule_index)
+            molecules_info[molecule_id] = {}
+            for residue in residue_list:
+                if first_residue:
+                    if list_of_first_residue_positions == None:
+                        residue_position = None
+                    else:
+                        for item in list_of_first_residue_positions:
+                            residue_position = [self.np.array(list_of_first_residue_positions[pos_index])]
+                    # Generate an arbitrary random unit vector
+                    backbone_vector = self.generate_random_points_in_a_sphere(center=[0,0,0], 
+                                                                radius=1, 
+                                                                n_samples=1,
+                                                                on_surface=True)[0]
+                    residues_info = self.create_residue(name=residue,
+                                                        number_of_residues=1, 
+                                                        espresso_system=espresso_system, 
+                                                        central_bead_position=residue_position,  
+                                                        use_default_bond= use_default_bond, 
+                                                        backbone_vector=backbone_vector)
+                    residue_id = next(iter(residues_info))
+                    for index in self.df[self.df['residue_id']==residue_id].index:
+                        self.add_value_to_df(key=('molecule_id',''),
+                                            index=int (index),
+                                            new_value=molecule_id)
+                    central_bead_id = residues_info[residue_id]['central_bead_id']
+                    previous_residue = residue
+                    residue_position = espresso_system.part.by_id(central_bead_id).pos
+                    previous_residue_id = central_bead_id
+                    first_residue = False          
+                else:                    
+                    previous_central_bead_name=self.df[self.df['name']==previous_residue].central_bead.values[0]
+                    new_central_bead_name=self.df[self.df['name']==residue].central_bead.values[0]       
+                    bond = self.search_bond(particle_name1=previous_central_bead_name, 
+                                            particle_name2=new_central_bead_name, 
+                                            hard_check=True, 
+                                            use_default_bond=use_default_bond)                
+                    l0 = self.get_bond_length(particle_name1=previous_central_bead_name, 
+                                            particle_name2=new_central_bead_name, 
+                                            hard_check=True, 
+                                            use_default_bond=use_default_bond)                
+                    residue_position = residue_position+backbone_vector*l0
+                    residues_info = self.create_residue(name=residue, 
+                                                        number_of_residues=1, 
+                                                        espresso_system=espresso_system, 
+                                                        central_bead_position=[residue_position],
+                                                        use_default_bond= use_default_bond, 
+                                                        backbone_vector=backbone_vector)
+                    residue_id = next(iter(residues_info))      
+                    for index in self.df[self.df['residue_id']==residue_id].index:
+                        if not self.check_if_df_cell_has_a_value(index=index,key=('molecule_id','')):
+                            self.df.at[index,'molecule_id'] = molecule_id
                             self.add_value_to_df(key=('molecule_id',''),
                                                 index=int (index),
-                                                new_value=molecule_id)
-                        central_bead_id = residues_info[residue_id]['central_bead_id']
-                        previous_residue = residue
-                        residue_position = espresso_system.part.by_id(central_bead_id).pos
-                        previous_residue_id = central_bead_id
-                        first_residue = False          
-                    else:                    
-                        previous_central_bead_name=self.df[self.df['name']==previous_residue].central_bead.values[0]
-                        new_central_bead_name=self.df[self.df['name']==residue].central_bead.values[0]       
-                        bond = self.search_bond(particle_name1=previous_central_bead_name, 
-                                                particle_name2=new_central_bead_name, 
-                                                hard_check=True, 
-                                                use_default_bond=use_default_bond)                
-                        l0 = self.get_bond_length(particle_name1=previous_central_bead_name, 
-                                                particle_name2=new_central_bead_name, 
-                                                hard_check=True, 
-                                                use_default_bond=use_default_bond)                
-                        residue_position = residue_position+backbone_vector*l0
-                        residues_info = self.create_residue(name=residue, 
-                                                            number_of_residues=1, 
-                                                            espresso_system=espresso_system, 
-                                                            central_bead_position=[residue_position],
-                                                            use_default_bond= use_default_bond, 
-                                                            backbone_vector=backbone_vector)
-                        residue_id = next(iter(residues_info))      
-                        for index in self.df[self.df['residue_id']==residue_id].index:
-                            if not self.check_if_df_cell_has_a_value(index=index,key=('molecule_id','')):
-                                self.df.at[index,'molecule_id'] = molecule_id
-                                self.add_value_to_df(key=('molecule_id',''),
-                                                    index=int (index),
-                                                    new_value=molecule_id,
-                                                    warning=False)            
-                        central_bead_id = residues_info[residue_id]['central_bead_id']
-                        espresso_system.part.by_id(central_bead_id).add_bond((bond, previous_residue_id))
-                        self.add_bond_in_df(particle_id1=central_bead_id,
-                                            particle_id2=previous_residue_id,
-                                            use_default_bond=use_default_bond)            
-                        previous_residue_id = central_bead_id
-                        previous_residue = residue                    
-                    molecule_info.append(residues_info)
-                first_residue = True
-                pos_index+=1
-            
-            return molecule_info
+                                                new_value=molecule_id,
+                                                warning=False)            
+                    central_bead_id = residues_info[residue_id]['central_bead_id']
+                    espresso_system.part.by_id(central_bead_id).add_bond((bond, previous_residue_id))
+                    self.add_bond_in_df(particle_id1=central_bead_id,
+                                        particle_id2=previous_residue_id,
+                                        use_default_bond=use_default_bond)            
+                    previous_residue_id = central_bead_id
+                    previous_residue = residue                    
+                molecules_info[molecule_id][residue_id] = residues_info[residue_id]
+            first_residue = True
+            pos_index+=1
+        
+        return molecules_info
     
     def create_particle(self, name, espresso_system, number_of_particles, position=None, fix=False):
         """

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -455,6 +455,8 @@ class pymbe_library():
             molecule_id(`int`): Id of the molecule to be centered.
             espresso_system(`obj`): Instance of a system object from the espressomd library.
         """
+        if len(self.df.loc[self.df['molecule_id']==molecule_id].pmb_type) == 0:
+            raise ValueError("The provided molecule_id is not present in the pyMBE dataframe.")      
         center_of_mass = self.calculate_center_of_mass_of_molecule(molecule_id=molecule_id,espresso_system=espresso_system)
         box_center = [espresso_system.box_l[0]/2.0,
                       espresso_system.box_l[1]/2.0,

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -939,7 +939,7 @@ class pymbe_library():
             df_index=int (index_list[index])
             self.clean_df_row(index=df_index)
             if position is None:
-                particle_position = self.np.random.random((1, 3))[0] *self.np.copy(espresso_system.box_l)
+                particle_position = self.rng.random((1, 3))[0] *self.np.copy(espresso_system.box_l)
             else:
                 particle_position = position[index]
             if len(espresso_system.part.all()) == 0:
@@ -955,7 +955,7 @@ class pymbe_library():
             self.add_value_to_df(key=('particle_id',''),index=df_index,new_value=bead_id, warning=False)                  
         return created_pid_list
 
-    def create_pmb_object (self, name, number_of_objects, espresso_system, position=None, use_default_bond=False):
+    def create_pmb_object(self, name, number_of_objects, espresso_system, position=None, use_default_bond=False):
         """
         Creates all `particle`s associated to `pmb object` into  `espresso` a number of times equal to `number_of_objects`.
         
@@ -976,9 +976,9 @@ class pymbe_library():
         if pmb_type == 'particle':
             self.create_particle(name=name, number_of_particles=number_of_objects, espresso_system=espresso_system, position=position)
         elif pmb_type == 'residue':
-            self.create_residue(name=name,number_of_residues=number_of_objects, espresso_system=espresso_system, central_bead_position=position,use_default_bond=use_default_bond)
+            self.create_residue(name=name, number_of_residues=number_of_objects, espresso_system=espresso_system, central_bead_position=position,use_default_bond=use_default_bond)
         elif pmb_type == 'molecule':
-            self.create_molecule(name=name,number_of_molecules=number_of_objects, espresso_system=espresso_system, use_default_bond=use_default_bond, list_of_first_residue_positions=position)
+            self.create_molecule(name=name, number_of_molecules=number_of_objects, espresso_system=espresso_system, use_default_bond=use_default_bond, list_of_first_residue_positions=position)
         return
 
     def create_protein(self, name, number_of_proteins, espresso_system, topology_dict):

--- a/samples/Beyer2024/create_paper_data.py
+++ b/samples/Beyer2024/create_paper_data.py
@@ -7,7 +7,7 @@ import argparse
 import subprocess
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 valid_fig_labels=["7a", "7b", "7c", "8a", "8b", "9"]
 valid_modes=["short-run","long-run", "test"]

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 # Create an instance of pyMBE library
 import pyMBE
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 #Import functions from handy_functions script 
 from lib.handy_functions import setup_electrostatic_interactions
@@ -76,7 +76,7 @@ inputs={"pH": args.pH,
         "protein_pdb": args.pdb}
 
 #System Parameters 
-SEED = 77 
+LANGEVIN_SEED = 77 
 
 c_salt    =  0.01  * pmb.units.mol / pmb.units.L  
 c_protein =  2e-4 * pmb.units.mol / pmb.units.L 
@@ -198,8 +198,7 @@ if verbose:
 
 #Setup of the reactions in espresso 
 RE, sucessfull_reactions_labels = pmb.setup_cpH(counter_ion=cation_name, 
-                                                constant_pH= pH_value, 
-                                                SEED = SEED )
+                                                constant_pH= pH_value)
 if verbose:
     print('The acid-base reaction has been sucessfully setup for ', sucessfull_reactions_labels)
 
@@ -232,7 +231,7 @@ pmb.write_output_vtf_file(espresso_system=espresso_system,
 
 setup_langevin_dynamics (espresso_system=espresso_system, 
                                     kT = pmb.kT, 
-                                    SEED = SEED)
+                                    SEED = LANGEVIN_SEED)
 
 observables_df = pmb.pd.DataFrame()
 time_step = []

--- a/samples/Beyer2024/peptide.py
+++ b/samples/Beyer2024/peptide.py
@@ -17,7 +17,7 @@ from lib import analysis
 from lib import handy_functions as hf
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 valid_modes=["short-run","long-run", "test"]
 parser = argparse.ArgumentParser(description='Script to run the peptide test cases for pyMBE')
@@ -51,7 +51,7 @@ verbose=args.no_verbose
 if mode not in valid_modes:
     raise ValueError(f"Mode {mode} is not currently supported, valid modes are {valid_modes}")
 
-SEED = 100
+LANGEVIN_SEED = 100
 dt = 0.01
 solvent_permitivity = 78.3
 pep_concentration = 5.56e-4 *pmb.units.mol/pmb.units.L
@@ -152,8 +152,7 @@ c_salt_calculated = pmb.create_added_salt(espresso_system=espresso_system,
                     verbose=verbose)
 
 RE, successful_reactions_labels = pmb.setup_cpH(counter_ion=cation_name,
-                                                constant_pH=pH,
-                                                SEED=SEED)
+                                                constant_pH=pH)
 
 if verbose:
     print(f"The box length of your system is {L.to('reduced_length')} = {L.to('nm')}")
@@ -184,7 +183,7 @@ hf.minimize_espresso_system_energy (espresso_system=espresso_system,
 
 hf.setup_langevin_dynamics(espresso_system=espresso_system,
                             kT = pmb.kT,
-                            SEED = SEED,
+                            SEED = LANGEVIN_SEED,
                             time_step=dt,
                             tune_skin=False)
 

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -21,7 +21,7 @@ import pyMBE
 from lib import analysis
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 # Load some functions from the handy_scripts library for convinience
 from lib.handy_functions import setup_electrostatic_interactions
@@ -80,7 +80,6 @@ solvent_permittivity = 78.9
 # Integration parameters
 DT = 0.01
 LANGEVIN_SEED = 42
-REACTION_SEED = 42
 
 # Parameters of the polyacid model
 Chain_length = 50
@@ -156,7 +155,7 @@ excess_chemical_potential_monovalent_pair_interpolated = interpolate.interp1d(io
 activity_coefficient_monovalent_pair = lambda x: np.exp(excess_chemical_potential_monovalent_pair_interpolated(x.to('1/(reduced_length**3 * N_A)').magnitude))
 if verbose:
     print("Setting up reactions...")
-RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_reactions(pH_res=pH_res, c_salt_res=c_salt_res, proton_name=proton_name, hydroxide_name=hydroxide_name, salt_cation_name=sodium_name, salt_anion_name=chloride_name, SEED=REACTION_SEED, activity_coefficient=activity_coefficient_monovalent_pair, pka_set=pka_set)
+RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_reactions(pH_res=pH_res, c_salt_res=c_salt_res, proton_name=proton_name, hydroxide_name=hydroxide_name, salt_cation_name=sodium_name, salt_anion_name=chloride_name, activity_coefficient=activity_coefficient_monovalent_pair, pka_set=pka_set)
 if verbose:
     print('The acid-base reaction has been sucessfully set up for ', sucessful_reactions_labels)
 

--- a/samples/branched_polyampholyte.py
+++ b/samples/branched_polyampholyte.py
@@ -14,7 +14,7 @@ import pyMBE
 
 # Create an instance of pyMBE library
 
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 # Command line arguments
 parser = argparse.ArgumentParser(description='Script that runs a Monte Carlo simulation of an ideal branched polyampholyte using pyMBE and ESPResSo.')
@@ -41,7 +41,7 @@ MD_steps_per_sample = 1000
 steps_eq = int(Samples_per_pH/3)
 N_samples_print = 10  # Write the trajectory every 100 samples
 probability_reaction =0.5 
-SEED = 100
+LANGEVIN_SEED = 100
 dt = 0.001
 solvent_permitivity = 78.3
 N_polyampholyte_chains = 5
@@ -143,7 +143,7 @@ print("The box length of your system is", L.to('reduced_length'), L.to('nm'))
 print('The polyampholyte concentration in your system is ', calculated_polyampholyte_concentration.to('mol/L') , 'with', N_polyampholyte_chains, 'molecules')
 print('The ionisable groups in your polyampholyte are ', list_ionisible_groups)
 
-RE, sucessfull_reactions_labels = pmb.setup_cpH(counter_ion=cation_name, constant_pH=2, SEED=SEED)
+RE, sucessfull_reactions_labels = pmb.setup_cpH(counter_ion=cation_name, constant_pH=2)
 print('The acid-base reaction has been sucessfully setup for ', sucessfull_reactions_labels)
 
 # Setup espresso to track the ionization of the acid/basic groups 
@@ -159,7 +159,7 @@ print('The non interacting type is set to ', non_interacting_type)
 #Setup Langevin
 setup_langevin_dynamics(espresso_system=espresso_system, 
                                     kT = pmb.kT, 
-                                    SEED = SEED,
+                                    SEED = LANGEVIN_SEED,
                                     time_step=dt,
                                     tune_skin=False)
 

--- a/samples/peptide.py
+++ b/samples/peptide.py
@@ -13,7 +13,7 @@ from espressomd import electrostatics
 import pyMBE
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 # Load some functions from the handy_scripts library for convinience
 from lib.handy_functions import setup_electrostatic_interactions
@@ -33,7 +33,7 @@ MD_steps_per_sample = 1000
 steps_eq = int(Samples_per_pH/3)
 N_samples_print = 10  # Write the trajectory every 100 samples
 probability_reaction =0.5 
-SEED = 100
+LANGEVIN_SEED = 100
 dt = 0.001
 solvent_permitivity = 78.3
 
@@ -131,7 +131,7 @@ print("The box length of your system is", L.to('reduced_length'), L.to('nm'))
 print('The peptide concentration in your system is ', calculated_peptide_concentration.to('mol/L') , 'with', N_peptide_chains, 'peptides')
 print('The ionisable groups in your peptide are ', list_ionisible_groups)
 
-RE, sucessfull_reactions_labels = pmb.setup_cpH(counter_ion=cation_name, constant_pH=2, SEED=SEED)
+RE, sucessfull_reactions_labels = pmb.setup_cpH(counter_ion=cation_name, constant_pH=2)
 print('The acid-base reaction has been sucessfully setup for ', sucessfull_reactions_labels)
 
 # Setup espresso to track the ionization of the acid/basic groups in peptide
@@ -155,7 +155,7 @@ minimize_espresso_system_energy (espresso_system=espresso_system)
 
 setup_langevin_dynamics(espresso_system=espresso_system, 
                                     kT = pmb.kT, 
-                                    SEED = SEED,
+                                    SEED = LANGEVIN_SEED,
                                     time_step=dt,
                                     tune_skin=False)
 

--- a/samples/peptide.py
+++ b/samples/peptide.py
@@ -88,7 +88,7 @@ pmb.define_default_bond(bond_type = 'harmonic',
                         bond_parameters = HARMONIC_parameters)
 
 
-# Defines the peptine in the pyMBE data frame
+# Defines the peptide in the pyMBE data frame
 peptide_name = 'generic_peptide'
 pmb.define_peptide (name=peptide_name, sequence=sequence, model=model)
 

--- a/samples/peptide_mixture_grxmc_ideal.py
+++ b/samples/peptide_mixture_grxmc_ideal.py
@@ -14,7 +14,7 @@ from espressomd import electrostatics
 import pyMBE
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 import warnings
 
@@ -54,7 +54,7 @@ MD_steps_per_sample = 0
 steps_eq = int(Samples_per_pH)
 N_samples_print = 1000  # Write the trajectory every 100 samples
 probability_reaction =1
-SEED = 42
+LANGEVIN_SEED = 42
 dt = 0.001
 solvent_permitivity = 78.3
 
@@ -173,9 +173,9 @@ total_ionisible_groups = len (list_ionisible_groups)
 print("The box length of your system is", L.to('reduced_length'), L.to('nm'))
 
 if args.mode == 'standard':
-    RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_reactions(pH_res=2, c_salt_res=c_salt, proton_name=proton_name, hydroxide_name=hydroxide_name, salt_cation_name=sodium_name, salt_anion_name=chloride_name, SEED=SEED)
+    RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_reactions(pH_res=2, c_salt_res=c_salt, proton_name=proton_name, hydroxide_name=hydroxide_name, salt_cation_name=sodium_name, salt_anion_name=chloride_name)
 elif args.mode == 'unified':
-    RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_unified(pH_res=2, c_salt_res=c_salt, cation_name=cation_name, anion_name=anion_name, SEED=SEED)
+    RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_unified(pH_res=2, c_salt_res=c_salt, cation_name=cation_name, anion_name=anion_name)
 print('The acid-base reaction has been sucessfully setup for ', sucessful_reactions_labels)
 
 # Setup espresso to track the ionization of the acid/basic groups in peptide
@@ -198,7 +198,7 @@ with open('frames/trajectory1.vtf', mode='w+t') as coordinates:
 # Setup espresso to do langevin dynamics
 espresso_system.time_step= dt 
 espresso_system.integrator.set_vv()
-espresso_system.thermostat.set_langevin(kT=pmb.kT.to('reduced_energy').magnitude, gamma=0.1, seed=SEED)
+espresso_system.thermostat.set_langevin(kT=pmb.kT.to('reduced_energy').magnitude, gamma=0.1, seed=LANGEVIN_SEED)
 
 N_frame=0
 Z_pH=[] # List of the average global charge at each pH
@@ -224,9 +224,9 @@ for index in range(len(pH_range)):
         time_series[label]=[]
 
     if args.mode == 'standard':
-        RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_reactions(pH_res=pH_value, c_salt_res=c_salt, proton_name=proton_name, hydroxide_name=hydroxide_name, salt_cation_name=sodium_name, salt_anion_name=chloride_name, SEED=SEED)
+        RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_reactions(pH_res=pH_value, c_salt_res=c_salt, proton_name=proton_name, hydroxide_name=hydroxide_name, salt_cation_name=sodium_name, salt_anion_name=chloride_name)
     elif args.mode == 'unified':
-        RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_unified(pH_res=pH_value, c_salt_res=c_salt, cation_name=cation_name, anion_name=anion_name, SEED=SEED)
+        RE, sucessful_reactions_labels, ionic_strength_res = pmb.setup_grxmc_unified(pH_res=pH_value, c_salt_res=c_salt, cation_name=cation_name, anion_name=anion_name)
 
     # Inner loop for sampling each pH value
 

--- a/samples/plot_HH.py
+++ b/samples/plot_HH.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 
 # Create an instance of pyMBE library
 import pyMBE
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 # Input parameters
 

--- a/samples/salt_solution_gcmc.py
+++ b/samples/salt_solution_gcmc.py
@@ -19,7 +19,7 @@ import pyMBE
 from lib import analysis
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 import warnings
 
@@ -68,7 +68,6 @@ solvent_permittivity = 78.9
 # Integration parameters
 DT = 0.01
 LANGEVIN_SEED = 42
-REACTION_SEED = 42
 
 # Define salt
 cation_name = 'Na'
@@ -98,9 +97,9 @@ if args.mode == "interacting":
     ionic_strength, excess_chemical_potential_monovalent_pairs_in_bulk_data, bjerrums, excess_chemical_potential_monovalent_pairs_in_bulk_data_error =np.loadtxt(f"{path_to_ex_pot}/excess_chemical_potential.dat", unpack=True)
     excess_chemical_potential_monovalent_pair_interpolated = interpolate.interp1d(ionic_strength, excess_chemical_potential_monovalent_pairs_in_bulk_data)
     activity_coefficient_monovalent_pair = lambda x: np.exp(excess_chemical_potential_monovalent_pair_interpolated(x.to('1/(reduced_length**3 * N_A)').magnitude))
-    RE = pmb.setup_gcmc(c_salt_res=c_salt_res, salt_cation_name=cation_name, salt_anion_name=anion_name, SEED=REACTION_SEED, activity_coefficient=activity_coefficient_monovalent_pair)
+    RE = pmb.setup_gcmc(c_salt_res=c_salt_res, salt_cation_name=cation_name, salt_anion_name=anion_name, activity_coefficient=activity_coefficient_monovalent_pair)
 elif args.mode == "ideal":
-    RE = pmb.setup_gcmc(c_salt_res=c_salt_res, salt_cation_name=cation_name, salt_anion_name=anion_name, SEED=REACTION_SEED)
+    RE = pmb.setup_gcmc(c_salt_res=c_salt_res, salt_cation_name=cation_name, salt_anion_name=anion_name)
 if verbose:
     print("Set up GCMC...")
 

--- a/testsuite/bond_tests.py
+++ b/testsuite/bond_tests.py
@@ -3,7 +3,7 @@ import pyMBE
 import numpy as np
         
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 def check_bond_setup(bond_object, input_parameters, bond_type):
         """

--- a/testsuite/cph_ideal_tests.py
+++ b/testsuite/cph_ideal_tests.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 script_path = pmb.get_resource(f"samples/branched_polyampholyte.py")
 data_path = pmb.get_resource(f"samples/data_polyampholyte_cph.csv")
 

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -3,7 +3,7 @@ import espressomd
 from espressomd import interactions
 # Create an instance of pyMBE library
 import pyMBE
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 print(f"***create_molecule with input position list unit test ***")
 print(f"*** Unit test: Check that the positions of the central bead of the first residue in the generated molecules are equal to the input positions***")

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -11,6 +11,7 @@ print(f"*** Unit test: Check that the positions of the central bead of the first
 pmb.set_reduced_units(unit_length=0.4*pmb.units.nm)
 solvent_permitivity = 78.3
 N_molecules = 3
+chain_length = 5
 molecule_concentration = 5.56e-4 *pmb.units.mol/pmb.units.L
 # Load peptide parametrization from Lunkad, R. et al.  Molecular Systems Design & Engineering (2021), 6(2), 122-131.
 
@@ -40,9 +41,9 @@ harmonic_bond = {'r_0'    : generic_bond_lenght,
 
 pmb.define_default_bond(bond_type = bond_type, bond_parameters = harmonic_bond)
 
-# Defines the peptine in the pyMBE data frame
+# Defines the peptide in the pyMBE data frame
 molecule_name = 'generic_molecule'
-pmb.define_molecule (name=molecule_name, residue_list = ['res1'])
+pmb.define_molecule(name=molecule_name, residue_list = ['res1']*chain_length)
 
 # Solution parameters
 cation_name = 'Na'
@@ -58,27 +59,51 @@ L = volume ** (1./3.) # Side of the simulation box
 calculated_peptide_concentration = N_molecules/(volume*pmb.N_A)
 
 # Create an instance of an espresso system
-espresso_system=espressomd.System (box_l = [L.to('reduced_length').magnitude]*3)
+espresso_system=espressomd.System(box_l = [L.to('reduced_length').magnitude]*3)
 
 # Add all bonds to espresso system
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
-molecule = pmb.create_molecule(name=molecule_name,
+molecules = pmb.create_molecule(name=molecule_name,
                         number_of_molecules= N_molecules,
                         espresso_system=espresso_system,
                         use_default_bond=True,
                         list_of_first_residue_positions = pos_list)
 
-###Running unit test here. Use np.testing.assert_almost_equal of the input position list and the central_bead_pos list under here.
+# Running unit test here. Use np.testing.assert_almost_equal of the input position list and the central_bead_pos list under here.
 central_bead_pos = []
-for molecule_map in molecule:
-            for molecule_id, info in molecule_map.items():
-                central_bead_id = info['central_bead_id']
-                side_chain_ids = info['side_chain_ids']
-                central_bead_pos.append(espresso_system.part.by_id(central_bead_id).pos.tolist())
-
+for molecule_id in molecules:
+    info = next(iter(molecules[molecule_id].values()))
+    central_bead_id = info['central_bead_id']
+    side_chain_ids = info['side_chain_ids']
+    central_bead_pos.append(espresso_system.part.by_id(central_bead_id).pos.tolist())
 
 np.testing.assert_almost_equal(pos_list, central_bead_pos)
+
+print(f"*** Unit test passed ***\n")
+
+
+print(f"*** Unit test: Check that center_molecule_in_simulation_box works correctly for cubic boxes***")
+
+molecule_id = pmb.df.loc[pmb.df['name']==molecule_name].molecule_id.values[0]
+pmb.center_molecule_in_simulation_box(molecule_id=molecule_id, espresso_system=espresso_system)
+center_of_mass = pmb.calculate_center_of_mass_of_molecule(molecule_id=molecule_id, espresso_system=espresso_system)
+center_of_mass_ref = [L.to('reduced_length').magnitude/2]*3
+
+np.testing.assert_almost_equal(center_of_mass, center_of_mass_ref)
+
+print(f"*** Unit test passed ***\n")
+
+
+print(f"*** Unit test: Check that center_molecule_in_simulation_box works correctly for non-cubic boxes***")
+
+espresso_system.change_volume_and_rescale_particles(d_new=3*L.to('reduced_length').magnitude, dir="z")
+molecule_id = pmb.df.loc[pmb.df['name']==molecule_name].molecule_id.values[2]
+pmb.center_molecule_in_simulation_box(molecule_id=molecule_id, espresso_system=espresso_system)
+center_of_mass = pmb.calculate_center_of_mass_of_molecule(molecule_id=molecule_id, espresso_system=espresso_system)
+center_of_mass_ref = [L.to('reduced_length').magnitude/2, L.to('reduced_length').magnitude/2, 1.5*L.to('reduced_length').magnitude]
+
+np.testing.assert_almost_equal(center_of_mass, center_of_mass_ref)
 
 print(f"*** Unit test passed ***")

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -9,7 +9,6 @@ print(f"***create_molecule with input position list unit test ***")
 print(f"*** Unit test: Check that the positions of the central bead of the first residue in the generated molecules are equal to the input positions***")
 # Simulation parameters
 pmb.set_reduced_units(unit_length=0.4*pmb.units.nm)
-SEED = 100
 solvent_permitivity = 78.3
 N_molecules = 3
 molecule_concentration = 5.56e-4 *pmb.units.mol/pmb.units.L

--- a/testsuite/gcmc_tests.py
+++ b/testsuite/gcmc_tests.py
@@ -31,7 +31,7 @@ def gcmc_test(mode):
     print(f"*** Test was successful ***")
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 script_path=pmb.get_resource(f"samples/salt_solution_gcmc.py")
 salt_concentrations=[0.0001, 0.001, 0.01, 0.1]

--- a/testsuite/generate_perpendicular_vectors_test.py
+++ b/testsuite/generate_perpendicular_vectors_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pyMBE
 from itertools import combinations
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 def check_if_different_perpendicular_vectors_are_generated(vector,magnitude,n=50):
     """

--- a/testsuite/generate_perpendicular_vectors_test.py
+++ b/testsuite/generate_perpendicular_vectors_test.py
@@ -40,7 +40,6 @@ print(f"*** Unit test: Check that the function creates perpendicular vectors to 
 vector = pmb.generate_random_points_in_a_sphere(center=[0,0,0],
                                                 radius=1, 
                                                 n_samples=1, 
-                                                seed=None, 
                                                 on_surface=True)[0]
 check_if_different_perpendicular_vectors_are_generated(vector=vector,
                                                     magnitude=1)
@@ -49,7 +48,6 @@ print(f"*** Unit test: Check that the function creates perpendicular vectors to 
 vector = pmb.generate_random_points_in_a_sphere(center=[1,2,3],
                                                 radius=1, 
                                                 n_samples=1, 
-                                                seed=None, 
                                                 on_surface=True)[0]
 check_if_different_perpendicular_vectors_are_generated(vector=vector,
                                                     magnitude=1)
@@ -58,7 +56,6 @@ print(f"*** Unit test: Check that the function creates perpendicular vectors wit
 vector = pmb.generate_random_points_in_a_sphere(center=[1,2,3],
                                                 radius=2, 
                                                 n_samples=1, 
-                                                seed=None, 
                                                 on_surface=True)[0]
 check_if_different_perpendicular_vectors_are_generated(vector=vector,
                                                         magnitude=3)

--- a/testsuite/globular_protein_tests.py
+++ b/testsuite/globular_protein_tests.py
@@ -56,7 +56,7 @@ def run_protein_test(script_path, test_pH_values, protein_pdb, rtol, atol,mode="
         raise RuntimeError
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 script_path=pmb.get_resource(f"samples/Beyer2024/globular_protein.py")
 test_pH_values=[2,5,7]

--- a/testsuite/grxmc_ideal_tests.py
+++ b/testsuite/grxmc_ideal_tests.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 script_path = pmb.get_resource(f"samples/peptide_mixture_grxmc_ideal.py")
 data_path = pmb.get_resource(f"samples/data_peptide_grxmc.csv")
 

--- a/testsuite/henderson_hasselbalch_tests.py
+++ b/testsuite/henderson_hasselbalch_tests.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pyMBE
 from itertools import combinations
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 print(f"*** Running HH tests ***\n")
 

--- a/testsuite/lj_tests.py
+++ b/testsuite/lj_tests.py
@@ -4,7 +4,7 @@ import numpy as np
 import warnings
         
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 print("*** LJ unit tests ***")
 print(f"*** Unit test: check that all LJ input parameters in define_particle are correctly stored in pmb.df***")

--- a/testsuite/peptide_tests.py
+++ b/testsuite/peptide_tests.py
@@ -50,7 +50,7 @@ def run_peptide_test(script_path,test_pH_values,sequence,rtol,atol,mode="test"):
         raise RuntimeError
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 script_path=pmb.get_resource(f"samples/Beyer2024/peptide.py")
 test_pH_values=[3,7,11]

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -6,7 +6,7 @@ from pandas.testing import assert_frame_equal
 
 # Create an instance of pyMBE library
 import pyMBE
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 print ('*** Unit tests: read and write from pyMBE dataframe ***')
 

--- a/testsuite/seed_test.py
+++ b/testsuite/seed_test.py
@@ -6,7 +6,7 @@ import pyMBE
 
 espresso_system = espressomd.System(box_l = [100]*3)
 
-def run_peptide_simulation(SEED):
+def build_peptide_in_espresso(SEED):
     pmb = pyMBE.pymbe_library(SEED=SEED)
 
     # Simulation parameters
@@ -53,8 +53,8 @@ def run_peptide_simulation(SEED):
 
 
 print(f"*** Check that the using the same SEED results in the same initial particle positions***")
-positions1 = run_peptide_simulation(42)
-positions2= run_peptide_simulation(42)
+positions1 = build_peptide_in_espresso(42)
+positions2 = build_peptide_in_espresso(42)
 
 np.testing.assert_almost_equal(positions1, positions2)
 

--- a/testsuite/seed_test.py
+++ b/testsuite/seed_test.py
@@ -1,0 +1,61 @@
+import numpy as np 
+import espressomd
+import warnings
+from espressomd import interactions
+import pyMBE
+
+espresso_system = espressomd.System(box_l = [100]*3)
+
+def run_peptide_simulation(SEED):
+    pmb = pyMBE.pymbe_library(SEED=SEED)
+
+    # Simulation parameters
+    pmb.set_reduced_units(unit_length=0.4*pmb.units.nm)
+
+    # Peptide parameters
+    sequence = 'EEEEEEE'
+    model = '2beadAA'  # Model with 2 beads per each aminoacid
+
+    # Load peptide parametrization from Lunkad, R. et al.  Molecular Systems Design & Engineering (2021), 6(2), 122-131.
+    path_to_interactions=pmb.get_resource("parameters/peptides/Lunkad2021.txt")
+    path_to_pka=pmb.get_resource("parameters/pka_sets/CRC1991.txt")
+    pmb.load_interaction_parameters(filename=path_to_interactions) 
+    pmb.load_pka_set(path_to_pka)
+
+    # Defines the peptide in the pyMBE data frame
+    peptide_name = 'generic_peptide'
+    pmb.define_peptide(name=peptide_name, sequence=sequence, model=model)
+
+    # Bond parameters
+    generic_bond_lenght=0.4 * pmb.units.nm
+    generic_harmonic_constant = 400 * pmb.units('reduced_energy / reduced_length**2')
+
+    HARMONIC_parameters = {'r_0'    : generic_bond_lenght,
+                           'k'      : generic_harmonic_constant}
+
+    pmb.define_default_bond(bond_type = 'harmonic',
+                            bond_parameters = HARMONIC_parameters)
+
+    # Add all bonds to espresso system
+    pmb.add_bonds_to_espresso(espresso_system=espresso_system)
+
+    # Create molecule in the espresso system
+    pmb.create_pmb_object(name=peptide_name, number_of_objects=1, espresso_system=espresso_system, use_default_bond=True)
+
+    # Extract positions of particles in the peptide
+    positions = []
+    molecule_id = pmb.df.loc[pmb.df['name']==peptide_name].molecule_id.values[0]
+    particle_id_list = pmb.df.loc[pmb.df['molecule_id']==molecule_id].particle_id.dropna().to_list()
+    for pid in particle_id_list:
+        positions.append(espresso_system.part.by_id(pid).pos)
+
+    return np.asarray(positions)
+
+
+print(f"*** Check that the using the same SEED results in the same initial particle positions***")
+positions1 = run_peptide_simulation(42)
+positions2= run_peptide_simulation(42)
+
+np.testing.assert_almost_equal(positions1, positions2)
+
+print(f"*** Test passed ***")

--- a/testsuite/set_particle_acidity_test.py
+++ b/testsuite/set_particle_acidity_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pyMBE
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 def check_acid_base_setup(input_parameters,acidity_setup):
     """

--- a/testsuite/weak_polyelectrolyte_dialysis_test.py
+++ b/testsuite/weak_polyelectrolyte_dialysis_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 # Create an instance of pyMBE library
-pmb = pyMBE.pymbe_library()
+pmb = pyMBE.pymbe_library(SEED=42)
 
 script_path=pmb.get_resource(f"samples/Beyer2024/weak_polyelectrolyte_dialysis.py")
 test_pH_values=[3,5,7,9]

--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb = pyMBE.pymbe_library()"
+    "pmb = pyMBE.pymbe_library(SEED=42)"
    ]
   },
   {

--- a/tutorials/solution_tutorial.ipynb
+++ b/tutorials/solution_tutorial.ipynb
@@ -57,7 +57,7 @@
     "from PIL import Image\n",
     "\n",
     "\n",
-    "pmb = pyMBE.pymbe_library()\n",
+    "pmb = pyMBE.pymbe_library(SEED=42)\n",
     "\n",
     "pmb.set_reduced_units(unit_length = 1.5*pmb.units.nm,  \n",
     "                      unit_charge = 5*pmb.units.e)\n",


### PR DESCRIPTION
Solves #44, #43 

@pm-blanco I have made the `SEED` a mandatory attribute of the `pmb` class, which is now used to set up the various reaction methods. Furthermore, I have added an attribute `rng` that is initialized using the provided `SEED` and used in `generate_random_points_in_a_sphere`. This way it is avoided that the `rng`, which was before initialized within `generate_random_points_in_a_sphere`, is each time re-initialized with the same seed. 

All samples, tests, etc. have been updated accordingly.

Moreover, I have also fixed the bug discovered by @kosovan regarding non-cubic simulation boxes (#43) 