### PR TITLE
Fix wrong setup of LJ, improve CI and coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ unit_tests:
 	${PYTHON} testsuite/read-write-df_test.py
 	${PYTHON} testsuite/parameter_test.py
 	${PYTHON} testsuite/henderson_hasselbalch_tests.py
+	${PYTHON} testsuite/calculate_net_charge_unit_test.py
+	${PYTHON} testsuite/setup_salt_ions_unit_tests.py
 
 functional_tests:
 	${PYTHON} testsuite/cph_ideal_tests.py

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ unit_tests:
 	${PYTHON} testsuite/set_particle_acidity_test.py
 	${PYTHON} testsuite/bond_tests.py
 	${PYTHON} testsuite/generate_perpendicular_vectors_test.py
+	${PYTHON} testsuite/define_and_create_molecules_unit_tests.py
 	${PYTHON} testsuite/create_molecule_position_test.py
 	${PYTHON} testsuite/seed_test.py
 	${PYTHON} testsuite/read-write-df_test.py

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ unit_tests:
 	${PYTHON} testsuite/henderson_hasselbalch_tests.py
 	${PYTHON} testsuite/calculate_net_charge_unit_test.py
 	${PYTHON} testsuite/setup_salt_ions_unit_tests.py
+	${PYTHON} testsuite/globular_protein_unit_tests.py
 
 functional_tests:
 	${PYTHON} testsuite/cph_ideal_tests.py

--- a/lib/create_cg_from_pdb.py
+++ b/lib/create_cg_from_pdb.py
@@ -279,10 +279,10 @@ def create_sidechain_beads  (pdb_df) :
     pdb_df = pdb_df.loc[(pdb_df.atom_name != 'O') & (pdb_df.atom_name != 'C') & \
                 (pdb_df.atom_name != 'N') & (pdb_df.atom_name != 'CA') & (pdb_df.residue_name != 'GLY') & (pdb_df.atom_name != 'ca')  ]
 
-    pdb_df['sum_x_cm'] = pdb_df.groupby(['residue_number'])['x_cm'].transform(sum)
-    pdb_df['sum_y_cm'] = pdb_df.groupby(['residue_number'])['y_cm'].transform(sum)
-    pdb_df['sum_z_cm'] = pdb_df.groupby(['residue_number'])['z_cm'].transform(sum)
-    pdb_df['sum_mass'] = pdb_df.groupby(['residue_number'])['mass'].transform(sum)
+    pdb_df['sum_x_cm'] = pdb_df.groupby(['residue_number'])['x_cm'].transform("sum")
+    pdb_df['sum_y_cm'] = pdb_df.groupby(['residue_number'])['y_cm'].transform("sum")
+    pdb_df['sum_z_cm'] = pdb_df.groupby(['residue_number'])['z_cm'].transform("sum")
+    pdb_df['sum_mass'] = pdb_df.groupby(['residue_number'])['mass'].transform("sum")
     pdb_df['sum_res'] = pdb_df.groupby('residue_number')['residue_number'].transform('count')
 
     pdb_df['x_pos'] = pdb_df ['sum_x_cm']/ pdb_df['sum_mass']
@@ -298,7 +298,7 @@ def create_sidechain_beads  (pdb_df) :
     cols_to_sum = ['delta_x','delta_y','delta_z']
 
     pdb_df['sum_rg'] = pdb_df[cols_to_sum].sum(axis=1)
-    pdb_df['sum_rg'] = pdb_df.groupby(['residue_number'])['sum_rg'].transform(sum)
+    pdb_df['sum_rg'] = pdb_df.groupby(['residue_number'])['sum_rg'].transform("sum")
     pdb_df['radius_r'] = np.sqrt(pdb_df['sum_rg']/pdb_df['sum_res'],dtype='float').round(4)
 
     pdb_df = pdb_df.drop_duplicates(subset='residue_number')
@@ -310,7 +310,7 @@ def create_sidechain_beads  (pdb_df) :
     y_coord_r = pdb_df['y_pos']
     z_coord_r = pdb_df['z_pos']
 
-    pdb_df['radius_mean'] = pdb_df.groupby(['residue_name'])['radius_r'].transform (np.mean).round(4)
+    pdb_df['radius_mean'] = pdb_df.groupby(['residue_name'])['radius_r'].transform ("mean").round(4)
 
     atom_number_pdb_r = pd.Series(pdb_df.residue_number)
     resname_r = pd.Series(pdb_df.residue_name)
@@ -332,14 +332,12 @@ def check_sidechain_radius (pdb_df):
     Args:
         pdb_df (cls): pandas df with the protein information.
     """
-
-    for bead in pdb_df.residue_name.keys():
-        if pdb_df.sum_res[bead] == 1:
-            if pdb_df.residue_name[bead] == 'ALA':
-                pdb_df.radius_r [bead] = 1.0
-            else:
-                verbose_print (message=f'{pdb_df.residue_name[bead]} from chain {pdb_df.chain_id[bead]} has missing atoms.', verbose=args.verbose)
-                pdb_df.radius_r [bead] = 1.0
+    for index in pdb_df[pdb_df['sum_res']==1].index:
+        if pdb_df.loc[index, "residue_name"] == "ALA":
+            pdb_df.loc[index, "radius_r"] = 1
+        else:
+            verbose_print (message=f'{pdb_df.loc[index, "residue_name"]} from chain {pdb_df.loc[index, "chain_id"]} has missing atoms.', verbose=args.verbose)
+            pdb_df.loc[index, "radius_r"] = 1
     return 0
 
 def merge_alpha_carbon_and_sidechain (alpha_carbons_and_terminals,residues_bead):

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -154,7 +154,7 @@ class pymbe_library():
                 if verbose:
                     print(f"WARNING: you are attempting to redefine the properties of {name} of pmb_type {pmb_type}")    
                 if overwrite and verbose:
-                        print(f'WARNING: overwritting the value of the entry `{key}`: old_value = {old_value} new_value = {new_value}')
+                    print(f'WARNING: overwritting the value of the entry `{key}`: old_value = {old_value} new_value = {new_value}')
                 if not overwrite:
                     if verbose:
                         print(f"WARNING: pyMBE has preserved the old_value = {old_value}. If you want to overwrite it with new_value = {new_value}, activate the switch overwrite = True ")

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -866,9 +866,9 @@ class pymbe_library():
                 raise ValueError(f"Number of positions provided in {list_of_first_residue_positions} does not match number of molecules desired, {number_of_molecules}")
         if number_of_molecules <= 0:
             return
-        if not self.check_if_name_is_defined_in_df(name=name,
-                                                    pmb_type_to_be_defined='molecule'):
-            raise ValueError(f"{name} must correspond to a label of a pmb_type='molecule' defined on df")
+        self.check_if_name_is_defined_in_df(name=name,
+                                            pmb_type_to_be_defined='molecule')
+            
         first_residue = True
         molecules_info = {}
         residue_list = self.df[self.df['name']==name].residue_list.values [0]
@@ -899,7 +899,6 @@ class pymbe_library():
                                                                 n_samples=1,
                                                                 on_surface=True)[0]
                     residues_info = self.create_residue(name=residue,
-                                                        number_of_residues=1, 
                                                         espresso_system=espresso_system, 
                                                         central_bead_position=residue_position,  
                                                         use_default_bond= use_default_bond, 
@@ -929,7 +928,6 @@ class pymbe_library():
                                             use_default_bond=use_default_bond)                
                     residue_position = residue_position+backbone_vector*l0
                     residues_info = self.create_residue(name=residue, 
-                                                        number_of_residues=1, 
                                                         espresso_system=espresso_system, 
                                                         central_bead_position=[residue_position],
                                                         use_default_bond= use_default_bond, 
@@ -969,10 +967,12 @@ class pymbe_library():
         """       
         if number_of_particles <=0:
             return
-        if not self.check_if_name_is_defined_in_df(name=name,pmb_type_to_be_defined='particle'):
-            raise ValueError(f"{name} must correspond to a label of a pmb_type='particle' defined on df")
+        self.check_if_name_is_defined_in_df(name=name,
+                                       pmb_type_to_be_defined='particle')
         # Copy the data of the particle `number_of_particles` times in the `df`
-        self.copy_df_entry(name=name,column_name='particle_id',number_of_copies=number_of_particles)
+        self.copy_df_entry(name=name,
+                          column_name='particle_id',
+                          number_of_copies=number_of_particles)
         # Get information from the particle type `name` from the df     
         q = self.df.loc[self.df['name']==name].state_one.charge.values[0]
         es_type = self.df.loc[self.df['name']==name].state_one.es_type.values[0]
@@ -1020,11 +1020,21 @@ class pymbe_library():
         if pmb_type not in allowed_objects:
             raise ValueError('Object type not supported, supported types are ', allowed_objects)
         if pmb_type == 'particle':
-            self.create_particle(name=name, number_of_particles=number_of_objects, espresso_system=espresso_system, position=position)
+            self.create_particle(name=name, 
+                                number_of_particles=number_of_objects, 
+                                espresso_system=espresso_system, 
+                                position=position)
         elif pmb_type == 'residue':
-            self.create_residue(name=name, number_of_residues=number_of_objects, espresso_system=espresso_system, central_bead_position=position,use_default_bond=use_default_bond)
+            self.create_residue(name=name,  
+                                espresso_system=espresso_system, 
+                                central_bead_position=position,
+                                use_default_bond=use_default_bond)
         elif pmb_type == 'molecule':
-            self.create_molecule(name=name, number_of_molecules=number_of_objects, espresso_system=espresso_system, use_default_bond=use_default_bond, list_of_first_residue_positions=position)
+            self.create_molecule(name=name, 
+                                number_of_molecules=number_of_objects, 
+                                espresso_system=espresso_system, 
+                                use_default_bond=use_default_bond, 
+                                list_of_first_residue_positions=position)
         return
 
     def create_protein(self, name, number_of_proteins, espresso_system, topology_dict):
@@ -1040,12 +1050,11 @@ class pymbe_library():
 
         if number_of_proteins <=0:
             return
-        if not self.check_if_name_is_defined_in_df(name=name,
-                                                  pmb_type_to_be_defined='protein'):
-            raise ValueError(f"{name} must correspond to a name of a pmb_type='protein' defined on df")
-
-        self.copy_df_entry(name=name,column_name='molecule_id',number_of_copies=number_of_proteins)
-
+        self.check_if_name_is_defined_in_df(name=name,
+                                        pmb_type_to_be_defined='protein')
+        self.copy_df_entry(name=name,
+                            column_name='molecule_id',
+                            number_of_copies=number_of_proteins)
         protein_index = np.where(self.df['name']==name)
         protein_index_list =list(protein_index[0])[-number_of_proteins:]
         used_molecules_id = self.df.molecule_id.dropna().drop_duplicates().tolist()
@@ -1090,14 +1099,13 @@ class pymbe_library():
 
         return
 
-    def create_residue(self, name, espresso_system, number_of_residues, central_bead_position=None,use_default_bond=False, backbone_vector=None):
+    def create_residue(self, name, espresso_system, central_bead_position=None,use_default_bond=False, backbone_vector=None):
         """
-        Creates `number_of_residues` residues of type `name` into `espresso_system` and bookkeeps them into `pmb.df`.
+        Creates a residue of type `name` into `espresso_system` and bookkeeps them into `pmb.df`.
 
         Args:
             name(`str`): Label of the residue type to be created. `name` must be defined in `pmb.df`
             espresso_system(`obj`): Instance of a system object from espressomd library.
-            number_of_residue(`int`): Number of residues of type `name` to be created.
             central_bead_position(`list` of `float`): Position of the central bead.
             use_default_bond (`bool`): Switch to control if a bond of type `default` is used to bond a particle whose bonds types are not defined in `pmb.df`
             backbone_vector (`list` of `float`): Backbone vector of the molecule. All side chains are created perpendicularly to `backbone_vector`.
@@ -1105,17 +1113,15 @@ class pymbe_library():
         Returns:
             residues_info (`dict`): {residue_id:{"central_bead_id":central_bead_id, "side_chain_ids":[particle_id1, ...]}}
         """
-        if number_of_residues <= 0:
-            return
-        if not self.check_if_name_is_defined_in_df(name=name,
-                                                    pmb_type_to_be_defined='residue'):
-            raise ValueError(f"{name} must correspond to a label of a pmb_type='residue' defined on df")
-        # Copy the data of a residue a `number_of_residues` times in the `df
+        self.check_if_name_is_defined_in_df(name=name,
+                                            pmb_type_to_be_defined='residue')
+            
+        # Copy the data of a residue in the `df
         self.copy_df_entry(name=name,
                             column_name='residue_id',
-                            number_of_copies=number_of_residues)
+                            number_of_copies=1)
         residues_index = np.where(self.df['name']==name)
-        residue_index_list =list(residues_index[0])[-number_of_residues:]
+        residue_index_list =list(residues_index[0])[-1:]
         # Internal bookkepping of the residue info (important for side-chain residues)
         # Dict structure {residue_id:{"central_bead_id":central_bead_id, "side_chain_ids":[particle_id1, ...]}}
         residues_info={}
@@ -1127,9 +1133,7 @@ class pymbe_library():
             else:
                 residue_id = self.df['residue_id'].max() + 1
             self.add_value_to_df(key=('residue_id',''),index=int (residue_index),new_value=residue_id, verbose=False)
-            # create the principal bead
-            if self.df.loc[self.df['name']==name].central_bead.values[0] is np.NaN:
-                raise ValueError("central_bead must contain a particle name")        
+            # create the principal bead   
             central_bead_name = self.df.loc[self.df['name']==name].central_bead.values[0]            
             central_bead_id = self.create_particle(name=central_bead_name,
                                                                 espresso_system=espresso_system,
@@ -1201,8 +1205,10 @@ class pymbe_library():
                     else:
                         residue_position=central_bead_position+self.generate_trial_perpendicular_vector(vector=backbone_vector,
                                                                                                         magnitude=l0)
-                    lateral_residue_info = self.create_residue(name=side_chain_element, espresso_system=espresso_system,
-                        number_of_residues=1, central_bead_position=[residue_position],use_default_bond=use_default_bond)
+                    lateral_residue_info = self.create_residue(name=side_chain_element, 
+                                                                espresso_system=espresso_system,
+                                                                central_bead_position=[residue_position],
+                                                                use_default_bond=use_default_bond)
                     lateral_residue_dict=list(lateral_residue_info.values())[0]
                     central_bead_side_chain_id=lateral_residue_dict['central_bead_id']
                     lateral_beads_side_chain_ids=lateral_residue_dict['side_chain_ids']

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -81,8 +81,9 @@ class pymbe_library():
         Returns:
             index (`int`): Row index where the bond information has been added in pmb.df.
         """
-        particle_name1 = self.df.loc[self.df['particle_id']==particle_id1].name.values[0]
-        particle_name2 = self.df.loc[self.df['particle_id']==particle_id2].name.values[0]
+        particle_name1 = self.df.loc[(self.df['particle_id']==particle_id1) & (self.df['pmb_type']=="particle")].name.values[0]
+        particle_name2 = self.df.loc[(self.df['particle_id']==particle_id2) & (self.df['pmb_type']=="particle")].name.values[0]
+        
         bond_key = self.find_bond_key(particle_name1=particle_name1,
                                     particle_name2=particle_name2, 
                                     use_default_bond=use_default_bond)

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -218,7 +218,7 @@ class pymbe_library():
         """
         center_of_mass = np.zeros(3)
         axis_list = [0,1,2]
-        molecule_name = self.df.loc[(self.df['molecule_id']==molecule_id) & (self.df['pmb_type']=="molecule")].name.values[0]
+        molecule_name = self.df.loc[(self.df['molecule_id']==molecule_id) & (self.df['pmb_type'].isin(["molecule","protein"]))].name.values[0]
         particle_id_list = self.get_particle_id_map(object_name=molecule_name)["all"]
         for pid in particle_id_list:
             for axis in axis_list:
@@ -465,7 +465,7 @@ class pymbe_library():
         box_center = [espresso_system.box_l[0]/2.0,
                       espresso_system.box_l[1]/2.0,
                       espresso_system.box_l[2]/2.0]
-        molecule_name = self.df.loc[(self.df['molecule_id']==molecule_id) & (self.df['pmb_type']=="molecule")].name.values[0]
+        molecule_name = self.df.loc[(self.df['molecule_id']==molecule_id) & (self.df['pmb_type'].isin(["molecule","protein"]))].name.values[0]
         particle_id_list = self.get_particle_id_map(object_name=molecule_name)["all"]
         for pid in particle_id_list:
             es_pos = espresso_system.part.by_id(pid).pos
@@ -2197,11 +2197,11 @@ class pymbe_library():
                                 overwrite=overwrite)
             elif object_type == 'residue':
                 self.define_residue (name = param_dict.pop('name'),
-                                    central_bead = param_dict.pop('central_bead_name'),
-                                    side_chains = param_dict.pop('side_chains_names'))
+                                    central_bead = param_dict.pop('central_bead'),
+                                    side_chains = param_dict.pop('side_chains'))
             elif object_type == 'molecule':
                 self.define_molecule(name=param_dict.pop('name'),
-                                    residue_list=param_dict.pop('residue_name_list'))
+                                    residue_list=param_dict.pop('residue_list'))
             elif object_type == 'peptide':
                 self.define_peptide(name=param_dict.pop('name'),
                                     sequence=param_dict.pop('sequence'),
@@ -2227,7 +2227,9 @@ class pymbe_library():
                              }
                 else:
                     raise ValueError("Current implementation of pyMBE only supports harmonic and FENE bonds")
-                self.define_bond(bond_type=bond_type, bond_parameters=bond, particle_pairs=particle_pairs)
+                self.define_bond(bond_type=bond_type, 
+                                bond_parameters=bond, 
+                                particle_pairs=particle_pairs)
             else:
                 raise ValueError(object_type+' is not a known pmb object type')
             

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -881,7 +881,10 @@ class pymbe_library():
         used_molecules_id = self.df.molecule_id.dropna().drop_duplicates().tolist()
         pos_index = 0 
         for molecule_index in molecule_index_list:        
-            molecule_id = self.assign_molecule_id(name=name,pmb_type='molecule',used_molecules_id=used_molecules_id,molecule_index=molecule_index)
+            molecule_id = self.assign_molecule_id(name=name,
+                                                pmb_type='molecule',
+                                                used_molecules_id=used_molecules_id,
+                                                molecule_index=molecule_index)
             molecules_info[molecule_id] = {}
             for residue in residue_list:
                 if first_residue:
@@ -905,7 +908,9 @@ class pymbe_library():
                     for index in self.df[self.df['residue_id']==residue_id].index:
                         self.add_value_to_df(key=('molecule_id',''),
                                             index=int (index),
-                                            new_value=molecule_id)
+                                            new_value=molecule_id,
+                                            overwrite=False,
+                                            verbose=False)
                     central_bead_id = residues_info[residue_id]['central_bead_id']
                     previous_residue = residue
                     residue_position = espresso_system.part.by_id(central_bead_id).pos
@@ -936,7 +941,8 @@ class pymbe_library():
                             self.add_value_to_df(key=('molecule_id',''),
                                                 index=int (index),
                                                 new_value=molecule_id,
-                                                verbose=False)            
+                                                verbose=False,
+                                                overwrite=False)            
                     central_bead_id = residues_info[residue_id]['central_bead_id']
                     espresso_system.part.by_id(central_bead_id).add_bond((bond, previous_residue_id))
                     self.add_bond_in_df(particle_id1=central_bead_id,
@@ -1168,7 +1174,8 @@ class pymbe_library():
                     self.add_value_to_df(key=('residue_id',''),
                                         index=int (index),
                                         new_value=residue_id, 
-                                        verbose=False)
+                                        verbose=False,
+                                        overwrite=True)
                     side_chain_beads_ids.append(side_bead_id)
                     espresso_system.part.by_id(central_bead_id).add_bond((bond, side_bead_id))
                     self.add_bond_in_df(particle_id1=central_bead_id,
@@ -1203,7 +1210,8 @@ class pymbe_library():
                     self.add_value_to_df(key=('residue_id',''),
                                         index=int(index),
                                         new_value=residue_id, 
-                                        verbose=False)
+                                        verbose=False,
+                                        overwrite=True)
                     # Change the residue_id of the particles in the residue in the side chain
                     side_chain_beads_ids+=[central_bead_side_chain_id]+lateral_beads_side_chain_ids
                     for particle_id in side_chain_beads_ids:
@@ -1211,7 +1219,8 @@ class pymbe_library():
                         self.add_value_to_df(key=('residue_id',''),
                                             index=int (index),
                                             new_value=residue_id, 
-                                            verbose=False)
+                                            verbose=False,
+                                            overwrite=True)
                     espresso_system.part.by_id(central_bead_id).add_bond((bond, central_bead_side_chain_id))
                     self.add_bond_in_df(particle_id1=central_bead_id,
                                         particle_id2=central_bead_side_chain_id,

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -1492,22 +1492,6 @@ class pymbe_library():
             parameters[particle_name]["overwrite"]=overwrite
             self.define_particle(**parameters[particle_name])
         return
-
-    def define_particles_parameter_from_dict(self, param_dict, param_name):
-        '''
-        Defines the `param_name` value of the particles in `param_dict` into the `pmb.df`.
-
-        Args:
-            param_dict(`dict`):  {'name': `param_name` value}
-        '''
-        for residue in param_dict.keys():
-            label_list = self.df[self.df['name'] == residue].index.tolist()
-            for index in label_list:
-                value = param_dict[residue]
-                self.add_value_to_df(key= (param_name,''),
-                        index=int (index),
-                        new_value=value)
-        return 
     
     def define_peptide(self, name, sequence, model):
         """
@@ -2083,13 +2067,13 @@ class pymbe_library():
         type_map  = pd.concat([state_one,state_two],axis=0).to_dict()
         return type_map
 
-    def load_interaction_parameters(self, filename, verbose=True, overwrite=False):
+    def load_interaction_parameters(self, filename, verbose=False, overwrite=False):
         """
         Loads the interaction parameters stored in `filename` into `pmb.df`
         
         Args:
             filename(`str`): name of the file to be read
-            verbose (`bool`, optional): Switch to activate/deactivate verbose. Defaults to True.
+            verbose (`bool`, optional): Switch to activate/deactivate verbose. Defaults to False.
             overwrite(`bool`, optional): Switch to enable overwriting of already existing values in pmb.df. Defaults to False. 
         """
         without_units = ['q','es_type','acidity']

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -157,7 +157,7 @@ class pymbe_library():
                     print(f'WARNING: overwritting the value of the entry `{key}`: old_value = {old_value} new_value = {new_value}')
                 if not overwrite:
                     if verbose:
-                        print(f"WARNING: pyMBE has preserved the old_value = {old_value}. If you want to overwrite it with new_value = {new_value}, activate the switch overwrite = True ")
+                        print(f"WARNING: pyMBE has preserved of the entry `{key}`: old_value = {old_value}. If you want to overwrite it with new_value = {new_value}, activate the switch overwrite = True ")
                     return
         self.df.loc[index,idx[key]] = protect(new_value)
         if non_standard_value:
@@ -3227,23 +3227,3 @@ class pymbe_library():
         self.df.to_csv(filename)
 
         return
-
-    def write_output_vtf_file(self, espresso_system, filename):
-        '''
-        Writes a snapshot of `espresso_system` on the vtf file `filename`.
-
-        Args:
-            espresso_system(`obj`): Instance of a system object from the espressomd library.
-            filename(`str`): Path to the vtf file.
-
-        '''
-        box = espresso_system.box_l[0]
-        with open(filename, mode='w+t') as coordinates:
-            coordinates.write (f'unitcell {box} {box} {box} \n')
-            for particle in espresso_system.part: 
-                type_label = self.find_value_from_es_type(es_type=particle.type, column_name='label')
-                coordinates.write (f'atom {particle.id} radius 1 name {type_label} type {type_label}\n' )
-            coordinates.write ('timestep indexed\n')
-            for particle in espresso_system.part:
-                coordinates.write (f'{particle.id} \t {particle.pos[0]} \t {particle.pos[1]} \t {particle.pos[2]}\n')
-        return 

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -1078,11 +1078,15 @@ class pymbe_library():
                 
                 self.add_value_to_df(key=('residue_id',''),
                                             index=int (index),
-                                            new_value=residue_number)
+                                            new_value=residue_number,
+                                            overwrite=True,
+                                            verbose=False)
 
                 self.add_value_to_df(key=('molecule_id',''),
                                         index=int (index),
-                                        new_value=molecule_id)
+                                        new_value=molecule_id,
+                                        overwrite=True,
+                                        verbose=False)
 
         return
 

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -1475,13 +1475,14 @@ class pymbe_library():
                                 overwrite=overwrite)
         return 
     
-    def define_particles(self, parameters, overwrite=False):
+    def define_particles(self, parameters, overwrite=False, verbose=True):
         '''
         Defines a particle object in pyMBE for each particle name in `particle_names`
 
         Args:
             parameters(`dict`):  dictionary with the particle parameters. 
             overwrite(`bool`, optional): Switch to enable overwriting of already existing values in pmb.df. Defaults to False. 
+            verbose (`bool`, optional): Switch to activate/deactivate verbose. Defaults to True.
 
         Note:
             parameters = {"particle_name1: {"sigma": sigma_value, "epsilon": epsilon_value, ...}, particle_name2: {...},}
@@ -1490,6 +1491,7 @@ class pymbe_library():
             return
         for particle_name in parameters.keys():
             parameters[particle_name]["overwrite"]=overwrite
+            parameters[particle_name]["verbose"]=verbose
             self.define_particle(**parameters[particle_name])
         return
     
@@ -1515,7 +1517,7 @@ class pymbe_library():
             self.df.at [index,('sequence','')] = clean_sequence
         return
     
-    def define_protein(self, name,model, topology_dict, lj_setup_mode="wca"):
+    def define_protein(self, name,model, topology_dict, lj_setup_mode="wca", overwrite=False, verbose=True):
         """
         Defines a pyMBE object of type `protein` in `pymbe.df`.
 
@@ -1524,6 +1526,8 @@ class pymbe_library():
             model (`string`): Model name. Currently only models with 1 bead '1beadAA' or with 2 beads '2beadAA' per amino acid are supported.
             topology_dict (`dict`): {'initial_pos': coords_list, 'chain_id': id, 'radius': radius_value}
             lj_setup_mode(`str`): Key for the setup for the LJ potential. Defaults to "wca".
+            overwrite(`bool`, optional): Switch to enable overwriting of already existing values in pmb.df. Defaults to False. 
+            verbose (`bool`, optional): Switch to activate/deactivate verbose. Defaults to True.
 
         Note:
             - Currently, only `lj_setup_mode="wca"` is supported. This corresponds to setting up the WCA potential.
@@ -1551,7 +1555,9 @@ class pymbe_library():
                                         "name": particle_name}
             if self.check_aminoacid_key(key=particle_name):
                 sequence.append(particle_name)           
-        self.define_particles(parameters=part_dict)
+        self.define_particles(parameters=part_dict,
+                            overwrite=overwrite, 
+                            verbose=verbose)
         residue_list = self.define_AA_residues(sequence=sequence, 
                                                model=model)
         index = len(self.df)
@@ -2077,7 +2083,7 @@ class pymbe_library():
             overwrite(`bool`, optional): Switch to enable overwriting of already existing values in pmb.df. Defaults to False. 
         """
         without_units = ['q','es_type','acidity']
-        with_units = ['sigma','epsilon']
+        with_units = ['sigma','epsilon','offset','cutoff']
 
         with open(filename, 'r') as f:
             interaction_data = json.load(f)
@@ -2102,6 +2108,8 @@ class pymbe_library():
                 self.define_particle(name=param_dict.pop('name'),
                                 q=not_requiered_attributes.pop('q'),
                                 sigma=not_requiered_attributes.pop('sigma'),
+                                sigma=not_requiered_attributes.pop('offset'),
+                                sigma=not_requiered_attributes.pop('cutoff'),
                                 acidity=not_requiered_attributes.pop('acidity'),
                                 epsilon=not_requiered_attributes.pop('epsilon'),
                                 verbose=verbose,

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -149,15 +149,16 @@ class pymbe_library():
         if self.check_if_df_cell_has_a_value(index=index,key=key):
             old_value= self.df.loc[index,idx[key]]
             if protect(old_value) != protect(new_value):
+                name=self.df.loc[index,('name','')]
+                pmb_type=self.df.loc[index,('pmb_type','')]
                 if verbose:
-                    name=self.df.loc[index,('name','')]
-                    pmb_type=self.df.loc[index,('pmb_type','')]
-                    print(f"WARNING: you are attempting to redefine the properties of {name} of pmb_type {pmb_type}")
-                    if overwrite:
+                    print(f"WARNING: you are attempting to redefine the properties of {name} of pmb_type {pmb_type}")    
+                if overwrite and verbose:
                         print(f'WARNING: overwritting the value of the entry `{key}`: old_value = {old_value} new_value = {new_value}')
-                    else:
+                if not overwrite:
+                    if verbose:
                         print(f"WARNING: pyMBE has preserved the old_value = {old_value}. If you want to overwrite it with new_value = {new_value}, activate the switch overwrite = True ")
-                        return
+                    return
         self.df.loc[index,idx[key]] = protect(new_value)
         if non_standard_value:
             self.df[key] = self.df[key].apply(deprotect)

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -909,7 +909,7 @@ class pymbe_library():
                         self.add_value_to_df(key=('molecule_id',''),
                                             index=int (index),
                                             new_value=molecule_id,
-                                            overwrite=False,
+                                            overwrite=True,
                                             verbose=False)
                     central_bead_id = residues_info[residue_id]['central_bead_id']
                     previous_residue = residue
@@ -936,13 +936,11 @@ class pymbe_library():
                                                         backbone_vector=backbone_vector)
                     residue_id = next(iter(residues_info))      
                     for index in self.df[self.df['residue_id']==residue_id].index:
-                        if not self.check_if_df_cell_has_a_value(index=index,key=('molecule_id','')):
-                            self.df.at[index,'molecule_id'] = molecule_id
-                            self.add_value_to_df(key=('molecule_id',''),
-                                                index=int (index),
-                                                new_value=molecule_id,
-                                                verbose=False,
-                                                overwrite=False)            
+                        self.add_value_to_df(key=('molecule_id',''),
+                                            index=int (index),
+                                            new_value=molecule_id,
+                                            verbose=False,
+                                            overwrite=True)            
                     central_bead_id = residues_info[residue_id]['central_bead_id']
                     espresso_system.part.by_id(central_bead_id).add_bond((bond, previous_residue_id))
                     self.add_bond_in_df(particle_id1=central_bead_id,

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -1527,10 +1527,10 @@ class pymbe_library():
     
     def define_protein(self, name,model, topology_dict, lj_setup_mode="wca", overwrite=False, verbose=True):
         """
-        Defines a pyMBE object of type `protein` in `pymbe.df`.
+        Defines a globular protein pyMBE object  in `pymbe.df`.
 
         Args:
-            name (`str`): Unique label that identifies the `protein`.
+            name (`str`): Unique label that identifies the protein.
             model (`string`): Model name. Currently only models with 1 bead '1beadAA' or with 2 beads '2beadAA' per amino acid are supported.
             topology_dict (`dict`): {'initial_pos': coords_list, 'chain_id': id, 'radius': radius_value}
             lj_setup_mode(`str`): Key for the setup for the LJ potential. Defaults to "wca".
@@ -2393,8 +2393,7 @@ class pymbe_library():
                         atom_resname = line_split[5]
                         chain_id = line_split[9]
                         radius = float(line_split [11])*unit_length 
-                        sigma = 2*radius
-                        particles_dict [int(atom_id)] = [atom_name , atom_resname, chain_id, sigma]
+                        particles_dict [int(atom_id)] = [atom_name , atom_resname, chain_id, radius]
                     elif line_header.isnumeric(): 
                         atom_coord = line_split[1:] 
                         atom_coord = [(float(i)*unit_length).to('reduced_length').magnitude for i in atom_coord]

--- a/samples/Beyer2024/create_paper_data.py
+++ b/samples/Beyer2024/create_paper_data.py
@@ -56,16 +56,13 @@ if fig_label in labels_fig7:
         print(subprocess.list2cmdline(run_command))
         subprocess.check_output(run_command)
 
-
-
 ## Protein plots (Fig. 8)
-
 labels_fig8=["8a", "8b"]
 
 if fig_label in labels_fig8:
     
     script_path=pmb.get_resource("samples/Beyer2024/globular_protein.py")
-    pH_range = np.linspace(2, 7, num=11)
+    pH_range = np.linspace(2, 7, num=3)
     run_command_common=[sys.executable, script_path, "--mode", mode, "--no_verbose"]
 
     if fig_label == "8a":
@@ -156,10 +153,9 @@ if plot:
     elif fig_label in ["7c", "8a", "8b"]:
         pka_path=pmb.get_resource("parameters/pka_sets/Nozaki1967.json")
         pmb.load_pka_set (filename=pka_path)
-        # FIXME: this is only necessary due to an undesired feature in calculate_HH
-        # that forces to have all particles defined in pyMBE
-        par_path=pmb.get_resource("parameters/peptides/Blanco2021.json")
-        pmb.load_interaction_parameters(par_path)
+        if fig_label == "7c":
+            par_path=pmb.get_resource("parameters/peptides/Blanco2021.json")
+            pmb.load_interaction_parameters(par_path)
 
     # Load ref data    
     if fig_label == "7a":
@@ -209,14 +205,13 @@ if plot:
         pmb.define_protein (name=protein_pdb, 
                             topology_dict=topology_dict, 
                             model = '2beadAA')
-            
+
         pH_range_HH = np.linspace(2, 7, num=1000)
         
         Z_HH = pmb.calculate_HH(molecule_name=protein_pdb,
                                 pH_list=pH_range_HH)
 
-        print (Z_HH)
-         # Plot HH
+        # Plot HH
         plt.plot(pH_range_HH,
                Z_HH, 
                label=r"HH", 

--- a/samples/Beyer2024/create_paper_data.py
+++ b/samples/Beyer2024/create_paper_data.py
@@ -295,11 +295,8 @@ if plot:
         plt.xticks([2,4,6,8,10,12])
         
     elif fig_label in labels_fig8:   
-
         data=data.astype({("pH","value"): 'float'}).sort_values(by=("pH","value"))
         data=data[data.pdb.value == f'{protein_pdb}']
-
-
         plt.errorbar(data["pH"]["value"], 
                    data["mean","charge"], 
                    yerr=data["err_mean","charge"], 

--- a/samples/Beyer2024/create_paper_data.py
+++ b/samples/Beyer2024/create_paper_data.py
@@ -60,31 +60,17 @@ if fig_label in labels_fig7:
 labels_fig8=["8a", "8b"]
 
 if fig_label in labels_fig8:
-    
     script_path=pmb.get_resource("samples/Beyer2024/globular_protein.py")
-    pH_range = np.linspace(2, 7, num=3)
+    pH_range = np.linspace(2, 7, num=11)
     run_command_common=[sys.executable, script_path, "--mode", mode, "--no_verbose"]
-
-    if fig_label == "8a":
-        
-        protein_pdb = "1f6s"
-        path_to_cg = f"parameters/globular_proteins/{protein_pdb}.vtf"
-        for pH in pH_range:
-            
-            run_command=run_command_common + ["--pH", str(pH),"--pdb", protein_pdb, "--path_to_cg", path_to_cg, "--metal_ion_name", "Ca", "--metal_ion_charge", str(2)]
-            print(subprocess.list2cmdline(run_command))
-            subprocess.check_output(run_command)
-
-    elif fig_label == "8b":
-        protein_pdb = "1beb"
-        path_to_cg = f"parameters/globular_proteins/{protein_pdb}.vtf"
-        for pH in pH_range:
-            run_command=run_command_common + ["--pH", str(pH),"--pdb", protein_pdb, "--path_to_cg", path_to_cg]
-            print(subprocess.list2cmdline(run_command))
-            subprocess.check_output(run_command)
-    else:
-        raise RuntimeError()
-
+    pdb_codes={"8a":"1f6s",
+               "8b": "1beb"}
+    protein_pdb=pdb_codes[fig_label]
+    path_to_cg = f"parameters/globular_proteins/{protein_pdb}.vtf"
+    for pH in pH_range:        
+        run_command=run_command_common + ["--pH", str(pH),"--pdb", protein_pdb, "--path_to_cg", path_to_cg]
+        print(subprocess.list2cmdline(run_command))
+        subprocess.check_output(run_command)   
 
 ## Weak polyelectrolyte dialysis plot (Fig. 9)
 if fig_label == "9": 
@@ -204,7 +190,8 @@ if plot:
     
         pmb.define_protein (name=protein_pdb, 
                             topology_dict=topology_dict, 
-                            model = '2beadAA')
+                            model = '2beadAA',
+                            verbose= False)
 
         pH_range_HH = np.linspace(2, 7, num=1000)
         

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -62,7 +62,7 @@ parser.add_argument('--output',
                     required= False,
                     help='output directory')
 
-parser.add_argument('--no_verbose', action='store_false', help="Switch to deactivate verbose")
+parser.add_argument('--no_verbose', action='store_false', help="Switch to deactivate verbose",default=True)
 
 
 args = parser.parse_args ()
@@ -158,13 +158,14 @@ pmb.define_particle(name = anion_name,
 
 # Here we upload the pka set from the reference_parameters folder
 path_to_pka=pmb.get_resource('parameters/pka_sets/Nozaki1967.json') 
-pmb.load_pka_set (filename=path_to_pka)
+pmb.load_pka_set(filename=path_to_pka)
 
 #We create the protein in espresso 
 pmb.create_protein(name=protein_name,
                     number_of_proteins=1,
                     espresso_system=espresso_system,
                     topology_dict=topology_dict)
+
 #Here we activate the motion of the protein 
 if args.move_protein:
     pmb.enable_motion_of_rigid_object(espresso_system=espresso_system,
@@ -181,10 +182,10 @@ pmb.create_counterions (object_name=protein_name,
                         anion_name=anion_name,
                         espresso_system=espresso_system)
 
-c_salt_calculated = pmb.create_added_salt (espresso_system=espresso_system,
-                                            cation_name=cation_name,
-                                            anion_name=anion_name,
-                                            c_salt=c_salt)
+c_salt_calculated = pmb.create_added_salt(espresso_system=espresso_system,
+                                          cation_name=cation_name,
+                                          anion_name=anion_name,
+                                          c_salt=c_salt)
 
 #Here we calculated the ionisible groups 
 basic_groups = pmb.df.loc[(~pmb.df['particle_id'].isna()) & (pmb.df['acidity']=='basic')].name.to_list()

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -133,13 +133,6 @@ pmb.define_protein (name=protein_name,
                     model = '2beadAA',
                     lj_setup_mode = "wca")
 
-#Defines the metal ion present in the protein 
-if args.metal_ion_name is not None:
-    pmb.define_particle(name = args.metal_ion_name, 
-                        q=args.metal_ion_charge, 
-                        sigma=sigma, 
-                        epsilon=epsilon)
-
 # Here we define the solution particles in the pmb.df 
 cation_name = 'Na'
 anion_name = 'Cl'

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -41,16 +41,6 @@ parser.add_argument('--move_protein',
                     required= False, 
                     default=False,  
                     help='Activates the motion of the protein')
-parser.add_argument('--metal_ion_name', 
-                    type=str, 
-                    required= False, 
-                    default=None,  
-                    help='Name of the metal ion in the protein')
-parser.add_argument('--metal_ion_charge', 
-                    type=int, 
-                    required= False, 
-                    default=None,  
-                    help='Charge of the metal ion in the protein')
 
 parser.add_argument('--mode',
                     type=str,
@@ -64,12 +54,9 @@ parser.add_argument('--output',
 
 parser.add_argument('--no_verbose', action='store_false', help="Switch to deactivate verbose",default=True)
 
-
 args = parser.parse_args ()
-
 mode=args.mode
 verbose=args.no_verbose
-
 protein_name = args.pdb
 pH_value = args.pH 
 

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -4,7 +4,7 @@ import espressomd
 import argparse
 import numpy as np
 import pandas as pd 
-
+from espressomd.io.writer import vtf
 # Create an instance of pyMBE library
 import pyMBE
 pmb = pyMBE.pymbe_library(SEED=42)
@@ -206,8 +206,9 @@ if WCA:
 
 #Save the initial state 
 n_frame = 0
-pmb.write_output_vtf_file(espresso_system=espresso_system,
-                        filename=f"frames/trajectory{n_frame}.vtf")
+with open('frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
+                vtf.writevsf(espresso_system, coordinates)
+                vtf.writevcf(espresso_system, coordinates)
 
 setup_langevin_dynamics (espresso_system=espresso_system, 
                                     kT = pmb.kT, 
@@ -266,8 +267,9 @@ for step in tqdm(range(N_samples),disable=not verbose):
 
     if step % stride_traj == 0 :
         n_frame +=1
-        pmb.write_output_vtf_file(espresso_system=espresso_system,
-                                    filename=f"frames/trajectory{n_frame}.vtf")
+        with open('frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
+                vtf.writevsf(espresso_system, coordinates)
+                vtf.writevcf(espresso_system, coordinates)
 
     # Store observables
     time_series["time"].append(espresso_system.time)

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -207,8 +207,8 @@ if WCA:
 #Save the initial state 
 n_frame = 0
 with open('frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
-                vtf.writevsf(espresso_system, coordinates)
-                vtf.writevcf(espresso_system, coordinates)
+    vtf.writevsf(espresso_system, coordinates)
+    vtf.writevcf(espresso_system, coordinates)
 
 setup_langevin_dynamics (espresso_system=espresso_system, 
                                     kT = pmb.kT, 
@@ -268,8 +268,8 @@ for step in tqdm(range(N_samples),disable=not verbose):
     if step % stride_traj == 0 :
         n_frame +=1
         with open('frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
-                vtf.writevsf(espresso_system, coordinates)
-                vtf.writevcf(espresso_system, coordinates)
+            vtf.writevsf(espresso_system, coordinates)
+            vtf.writevcf(espresso_system, coordinates)
 
     # Store observables
     time_series["time"].append(espresso_system.time)

--- a/samples/Beyer2024/peptide.py
+++ b/samples/Beyer2024/peptide.py
@@ -31,7 +31,7 @@ parser.add_argument('--output',
                     type=str,
                     required= False,
                     help='output directory')
-parser.add_argument('--no_verbose', action='store_false', help="Switch to deactivate verbose")
+parser.add_argument('--no_verbose', action='store_false', help="Switch to deactivate verbose",default=True)
 args = parser.parse_args()
 
 # Inputs
@@ -66,8 +66,8 @@ if sequence in Lunkad_test_sequences:
     model = '2beadAA'  # Model with 2 beads per each aminoacid
     N_peptide_chains = 4
     sigma=1*pmb.units.Quantity("reduced_length")
-    offset_cation=0
-    offset_anion=0
+    offset_cation=0*pmb.units.Quantity("reduced_length")
+    offset_anion=0*pmb.units.Quantity("reduced_length")
     c_salt=1e-2 * pmb.units.mol/ pmb.units.L
     chain_length=len(sequence)*2
 

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -52,7 +52,8 @@ parser.add_argument('--output',
                     help='output directory')
 parser.add_argument('--no_verbose', 
                     action='store_false', 
-                    help="Switch to deactivate verbose")
+                    help="Switch to deactivate verbose",
+                    default=True)
 args = parser.parse_args()
 
 # Inputs

--- a/samples/peptide_mixture_grxmc_ideal.py
+++ b/samples/peptide_mixture_grxmc_ideal.py
@@ -77,14 +77,10 @@ if args.test:
 path_to_pka=pmb.get_resource("parameters/pka_sets/Hass2015.json")
 path_to_interactions=pmb.get_resource("parameters/peptides/Lunkad2021.json")
 
-
-
-
 pmb.load_interaction_parameters(filename=path_to_interactions) 
 with warnings.catch_warnings():
     warnings.simplefilter('error')
     pmb.load_pka_set(path_to_pka)
-
 
 # Defines the bonds
 
@@ -200,8 +196,6 @@ err_Z_pH=[] # List of the error of the global charge at each pH
 xi_plus=[] # List of the average partition coefficient of positive ions
 err_xi_plus=[] # List of the error of the partition coefficient of positive ions
 
-particle_id_list = pmb.df.loc[~pmb.df['molecule_id'].isna()].particle_id.dropna().to_list()
-
 #Save the pyMBE dataframe in a CSV file
 pmb.write_pmb_df (filename='df.csv')
 
@@ -230,16 +224,17 @@ for pH_value in pH_range:
             RE.reaction(reaction_steps = total_ionisible_groups)
 
         if step > steps_eq:
-            # Get peptide net charge      
-            z_one_object=0
-            for pid in particle_id_list:
-                z_one_object +=espresso_system.part.by_id(pid).q
-
+            # Get the net charge of the peptides
+            charge_dict_peptide_1=pmb.calculate_net_charge(espresso_system=espresso_system,
+                                                            molecule_name=peptide1)
+            charge_dict_peptide_2=pmb.calculate_net_charge(espresso_system=espresso_system,
+                                                            molecule_name=peptide2)
+            mean_charge=np.mean(np.array([charge_dict_peptide_1["mean"],charge_dict_peptide_2["mean"]]))
             if args.test:
                 time_series["time"].append(step)
             else:
                 time_series["time"].append(espresso_system.time)
-            time_series["charge"].append(np.mean((z_one_object)))
+            time_series["charge"].append(mean_charge)
 
             if args.mode == 'standard':
                 time_series["num_plus"].append(espresso_system.number_of_particles(type=type_map["Na"])+espresso_system.number_of_particles(type=type_map["Hplus"]))

--- a/testsuite/calculate_net_charge_unit_test.py
+++ b/testsuite/calculate_net_charge_unit_test.py
@@ -47,14 +47,12 @@ espresso_system=espressomd.System(box_l = [10]*3)
 
 # Add all bonds to espresso system
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
-pmb.write_pmb_df("df1.csv")
 
 # Create your molecules into the espresso system
 molecules = pmb.create_molecule(name=molecule_name,
                         number_of_molecules= 2,
                         espresso_system=espresso_system,
                         use_default_bond=True,)
-pmb.write_pmb_df("df2.csv")
 
 charge_map=pmb.calculate_net_charge(molecule_name=molecule_name,
                                     espresso_system=espresso_system)

--- a/testsuite/calculate_net_charge_unit_test.py
+++ b/testsuite/calculate_net_charge_unit_test.py
@@ -47,16 +47,19 @@ espresso_system=espressomd.System(box_l = [10]*3)
 
 # Add all bonds to espresso system
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
+pmb.write_pmb_df("df1.csv")
 
 # Create your molecules into the espresso system
 molecules = pmb.create_molecule(name=molecule_name,
                         number_of_molecules= 2,
                         espresso_system=espresso_system,
                         use_default_bond=True,)
+pmb.write_pmb_df("df2.csv")
 
 charge_map=pmb.calculate_net_charge(molecule_name=molecule_name,
                                     espresso_system=espresso_system)
 
+print(charge_map)
 # Check mean charge
 np.testing.assert_equal(charge_map["mean"],2.0)
 # Check molecule charge map

--- a/testsuite/calculate_net_charge_unit_test.py
+++ b/testsuite/calculate_net_charge_unit_test.py
@@ -59,7 +59,6 @@ pmb.write_pmb_df("df2.csv")
 charge_map=pmb.calculate_net_charge(molecule_name=molecule_name,
                                     espresso_system=espresso_system)
 
-print(charge_map)
 # Check mean charge
 np.testing.assert_equal(charge_map["mean"],2.0)
 # Check molecule charge map

--- a/testsuite/calculate_net_charge_unit_test.py
+++ b/testsuite/calculate_net_charge_unit_test.py
@@ -1,0 +1,73 @@
+import numpy as np
+import espressomd
+# Create an instance of pyMBE library
+import pyMBE
+pmb = pyMBE.pymbe_library(SEED=42)
+
+print("*** Unit test: check that calculate_net_charge calculates the charge in a molecule properly ***")
+
+pmb.define_particle(name='0P',
+                        q=0)
+
+pmb.define_particle(name='+1p',
+                    q=+1)
+
+pmb.define_particle(name='-1p',
+                    q=-1)
+
+pmb.define_residue(
+    name = 'R1',
+    central_bead = '+1p',
+    side_chains = ['0P']
+    )
+
+pmb.define_residue(
+    name = 'R2',
+    central_bead = '-1p',
+    side_chains = ['R1']
+    )
+
+bond_type = 'harmonic'
+generic_bond_length=0.4 * pmb.units.nm
+generic_harmonic_constant = 400 * pmb.units('reduced_energy / reduced_length**2')
+
+harmonic_bond = {'r_0'    : generic_bond_length,
+                 'k'      : generic_harmonic_constant,
+                }
+
+pmb.define_default_bond(bond_type = bond_type, 
+                        bond_parameters = harmonic_bond)
+
+molecule_name = 'generic_molecule'
+pmb.define_molecule(name=molecule_name, 
+                    residue_list = ['R1']*2+['R2']*3)
+
+# Create an instance of an espresso system
+espresso_system=espressomd.System(box_l = [10]*3)
+
+# Add all bonds to espresso system
+pmb.add_bonds_to_espresso(espresso_system=espresso_system)
+
+# Create your molecules into the espresso system
+molecules = pmb.create_molecule(name=molecule_name,
+                        number_of_molecules= 2,
+                        espresso_system=espresso_system,
+                        use_default_bond=True,)
+
+charge_map=pmb.calculate_net_charge(molecule_name=molecule_name,
+                                    espresso_system=espresso_system)
+
+# Check mean charge
+np.testing.assert_equal(charge_map["mean"],2.0)
+# Check molecule charge map
+np.testing.assert_equal(charge_map["molecules"],{0: 2.0, 1: 2.0})
+# Check residue charge map
+np.testing.assert_equal(charge_map["residues"],{0: 1.0, 1: 1.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 1.0, 6: 1.0, 7: 0.0, 8: 0.0, 9: 0.0})
+
+print("*** Unit test passed ***")
+print("*** Unit test: check that calculate_net_charge raises a ValueError if one provides the name of an object that is not a molecule ***")
+input_parameters={"molecule_name":"R1", 
+                   "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, pmb.calculate_net_charge, **input_parameters)
+print("*** Unit test passed ***")
+

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -63,13 +63,14 @@ espresso_system=espressomd.System(box_l = [L.to('reduced_length').magnitude]*3)
 # Add all bonds to espresso system
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
+pmb.write_pmb_df("df1.csv")
 # Create your molecules into the espresso system
 molecules = pmb.create_molecule(name=molecule_name,
                         number_of_molecules= N_molecules,
                         espresso_system=espresso_system,
                         use_default_bond=True,
                         list_of_first_residue_positions = pos_list)
-
+pmb.write_pmb_df("df2.csv")
 # Running unit test here. Use np.testing.assert_almost_equal of the input position list and the central_bead_pos list under here.
 central_bead_pos = []
 for molecule_id in molecules:

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -99,17 +99,26 @@ input_parameters={"name": "S2",
 np.testing.assert_raises(ValueError, pmb.create_molecule, **input_parameters)
 print("*** Unit test passed ***\n")
 
+print("*** Unit test: Check that create_molecule raises a ValueError if the user does not provide a the same number of first_residue_positions as number_of_molecules***")
+input_parameters={"name": "S2",
+                 "number_of_molecules": 2,
+                 "espresso_system": espresso_system,
+                 "list_of_first_residue_positions": [[1,2,3]]}
+np.testing.assert_raises(ValueError, pmb.create_molecule, **input_parameters)
+print("*** Unit test passed ***\n")
+
 print("*** Unit test: Check that center_molecule_in_simulation_box works correctly for cubic boxes***")
 
 molecule_id = pmb.df.loc[pmb.df['name']==molecule_name].molecule_id.values[0]
-pmb.center_molecule_in_simulation_box(molecule_id=molecule_id, espresso_system=espresso_system)
-center_of_mass = pmb.calculate_center_of_mass_of_molecule(molecule_id=molecule_id, espresso_system=espresso_system)
+pmb.center_molecule_in_simulation_box(molecule_id=molecule_id, 
+                                      espresso_system=espresso_system)
+center_of_mass = pmb.calculate_center_of_mass_of_molecule(molecule_id=molecule_id, 
+                                                          espresso_system=espresso_system)
 center_of_mass_ref = [L.to('reduced_length').magnitude/2]*3
 
 np.testing.assert_almost_equal(center_of_mass, center_of_mass_ref)
 
 print("*** Unit test passed ***\n")
-
 
 print("*** Unit test: Check that center_molecule_in_simulation_box works correctly for non-cubic boxes***")
 

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -13,7 +13,6 @@ solvent_permitivity = 78.3
 N_molecules = 3
 chain_length = 5
 molecule_concentration = 5.56e-4 *pmb.units.mol/pmb.units.L
-# Load peptide parametrization from Lunkad, R. et al.  Molecular Systems Design & Engineering (2021), 6(2), 122-131.
 
 pos_list = [[10,10,10], [20,20,20], [30,30,30]]
 pmb.define_particle(name='central_mon',

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -83,6 +83,21 @@ np.testing.assert_almost_equal(pos_list, central_bead_pos)
 
 print("*** Unit test passed ***\n")
 
+print("*** Unit test: Check that create_molecule raises a ValueError if the user does not provide a nested list for list_of_first_residue_positions***")
+input_parameters={"name": "S2",
+                 "number_of_molecules": 1,
+                 "espresso_system": espresso_system,
+                 "list_of_first_residue_positions": [1,2,3]}
+np.testing.assert_raises(ValueError, pmb.create_molecule, **input_parameters)
+print("*** Unit test passed ***\n")
+
+print("*** Unit test: Check that create_molecule raises a ValueError if the user does not provide a nested list with three coordinates***")
+input_parameters={"name": "S2",
+                 "number_of_molecules": 1,
+                 "espresso_system": espresso_system,
+                 "list_of_first_residue_positions": [[1,2]]}
+np.testing.assert_raises(ValueError, pmb.create_molecule, **input_parameters)
+print("*** Unit test passed ***\n")
 
 print("*** Unit test: Check that center_molecule_in_simulation_box works correctly for cubic boxes***")
 
@@ -107,3 +122,4 @@ center_of_mass_ref = [L.to('reduced_length').magnitude/2, L.to('reduced_length')
 np.testing.assert_almost_equal(center_of_mass, center_of_mass_ref)
 
 print("*** Unit test passed ***")
+

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -5,7 +5,7 @@ import pyMBE
 pmb = pyMBE.pymbe_library(SEED=42)
 
 print("***create_molecule with input position list unit test ***")
-print("*** Unit test: Check that the positions of the central bead of the first residue in the generated molecules are equal to the input positions***")
+print("*** Unit test: Check that the positions of the central bead of the first residue in the generated molecules are equal to the input positions ***")
 # Simulation parameters
 pmb.set_reduced_units(unit_length=0.4*pmb.units.nm,
                       verbose=False)

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -1,0 +1,219 @@
+
+# Import pyMBE and other libraries
+import pyMBE
+import numpy as np
+import warnings
+import espressomd
+
+# Create an instance of pyMBE library
+pmb = pyMBE.pymbe_library(SEED=42)
+
+# The unit tests for define_particle are in lj_tests.py and set_particle_acidity
+
+def check_setup(input_parameters, object_name):
+    """
+    Checks if pyMBE stores in the pmb.df the input parameters  correctly.
+
+    Args:
+        input_parameters(`dict`): dictionary with the input parameters.
+    """
+    # Checks that the input parameters are stored properly
+    for index in pmb.df[pmb.df['name']==object_name].index:
+        for parameter_key in input_parameters.keys():
+            if parameter_key != "name":
+                np.testing.assert_equal(actual=pmb.df.loc[index, parameter_key].values[0].to("nm").magnitude, 
+                                        desired=input_parameters[parameter_key].to("nm").magnitude, 
+                                        verbose=True)    
+
+print("*** Unit test: check that define_particles() does not setup any particle if no parameters are provided ***")
+pmb.define_particles(parameters={})
+if not pmb.df.empty:
+    RuntimeError("UNIT TEST FAILED")
+print("*** Unit test passed ***")
+
+
+
+print("*** Unit test: check that define_particles() defines a set of particles correctly ***")
+particle_parameters={"S1":{"name": "S1",
+                 "sigma":1*pmb.units.nm,
+                 "q":0},
+            "S2":{"name": "S2",
+                 "sigma":2*pmb.units.nm,
+                 "q": 1},
+            "S3":{"name": "S3",
+                 "sigma":3*pmb.units.nm,
+                 "q":2}}
+pmb.define_particles(parameters=particle_parameters)
+
+for particle_name in particle_parameters.keys():
+    input_parameters=particle_parameters[particle_name]
+    for index in pmb.df[pmb.df['name']==particle_name].index:
+        np.testing.assert_equal(actual=str(pmb.df.loc[index, "pmb_type"].values[0]), 
+                                desired="particle", 
+                                verbose=True)
+        np.testing.assert_equal(actual=pmb.df.loc[index, "sigma"].values[0].to("nm").magnitude, 
+                                desired=input_parameters["sigma"].to("nm").magnitude, 
+                                verbose=True)
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that define_residue() stores the parameters correctly in pmb.df ***")
+
+residue_parameters={"R1":{"name": "R1",
+                 "central_bead": "S1",
+                 "side_chains": []},
+            "R2":{"name": "R2",
+                 "central_bead": "S1",
+                 "side_chains": ["S2","S3"]},
+            "R3":{"name": "R3",
+                 "central_bead": "S2",
+                 "side_chains": ["R1"]}}
+
+for parameter_set in residue_parameters.values():
+    pmb.define_residue(**parameter_set)
+
+for residue_name in residue_parameters.keys():
+    input_parameters=residue_parameters[residue_name]
+    for index in pmb.df[pmb.df['name']==residue_name].index:
+        np.testing.assert_equal(actual=str(pmb.df.loc[index, "pmb_type"].values[0]), 
+                                desired="residue", 
+                                verbose=True)
+        np.testing.assert_equal(actual=str(pmb.df.loc[index, "central_bead"].values[0]), 
+                                desired=input_parameters["central_bead"], 
+                                verbose=True)
+        np.testing.assert_equal(actual=pmb.df.loc[index, "side_chains"].values[0], 
+                                desired=input_parameters["side_chains"], 
+                                verbose=True)
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that define_residue() raises a ValueError if the user provides an already defined name  ***")
+input_parameters={"name": "S3",
+                 "central_bead": "S2",
+                 "side_chains": ["R1"]}
+np.testing.assert_raises(ValueError, pmb.define_residue, **input_parameters)
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that define_molecule() stores the parameters correctly in pmb.df ***")
+
+molecule_parameters={"M1":{"name": "M1",
+                     "residue_list": []},
+                    "M2":{"name": "M2",
+                    "residue_list": ["R1","R2","R3"]}}
+
+for parameter_set in molecule_parameters.values():
+    pmb.define_molecule(**parameter_set)
+
+for molecule_name in molecule_parameters.keys():
+    input_parameters=molecule_parameters[molecule_name]
+    for index in pmb.df[pmb.df['name']==molecule_name].index:
+        np.testing.assert_equal(actual=str(pmb.df.loc[index, "pmb_type"].values[0]), 
+                                desired="molecule", 
+                                verbose=True)
+        np.testing.assert_equal(actual=pmb.df.loc[index, "residue_list"].values[0], 
+                                desired=input_parameters["residue_list"], 
+                                verbose=True)
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that define_molecule() raises a ValueError if the user provides an already defined name  ***")
+input_parameters={"name": "S3",
+                 "residue_list": ["R1"]}
+np.testing.assert_raises(ValueError, pmb.define_molecule, **input_parameters)
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_particle() creates particles into the espresso_system with the properties defined in pmb.df  ***")
+# Create an instance of an espresso system
+espresso_system=espressomd.System(box_l = [10]*3)
+particle_positions=[[0,0,0],[1,1,1]]
+pmb.create_particle(name="S1",
+                    espresso_system=espresso_system,
+                    number_of_particles=2,
+                    fix=True,
+                    position=particle_positions)
+
+particle_ids=pmb.get_particle_id_map(object_name="S1")["all"]
+type_map=pmb.get_type_map()
+
+for pid in particle_ids:
+    particle=espresso_system.part.by_id(pid)
+    np.testing.assert_equal(actual=particle.type, 
+                                desired=type_map["S1"], 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.q, 
+                                desired=particle_parameters["S1"]["q"], 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.fix, 
+                                desired=[True]*3, 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.pos, 
+                                desired=particle_positions[pid], 
+                                verbose=True)
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_particle() does not create any particle for number_of_particles <= 0  ***")
+
+pmb.create_particle(name="S1",
+                    espresso_system=espresso_system,
+                    number_of_particles=0)
+pmb.create_particle(name="S1",
+                    espresso_system=espresso_system,
+                    number_of_particles=-1)
+# If no particles have been created, only two particles should be in the system (from the previous test)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                                desired=2, 
+                                verbose=True)
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_particle() raises a ValueError if the user provides the name of an object that is not a particle ***")
+input_parameters={"name": "R2",
+                 "espresso_system": espresso_system,
+                 "number_of_particles": 1}
+np.testing.assert_raises(ValueError, pmb.create_particle, **input_parameters)
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_residue() creates residues into the espresso_system with the properties defined in pmb.df  ***")
+
+bond_type = 'harmonic'
+bond = {'r_0'    : 0.4*pmb.units.nm,
+        'k'      : 400 * pmb.units('reduced_energy / reduced_length**2')}
+
+pmb.define_default_bond(bond_type = bond_type,
+                        bond_parameters = bond)
+
+pmb.add_bonds_to_espresso(espresso_system=espresso_system)
+
+central_bead_position=[[0,0,0]]
+backbone_vector=[1.,2.,3.]
+pmb.create_residue(name="R2",
+                    espresso_system=espresso_system,
+                    number_of_residues=2,
+                    central_bead_position=central_bead_position,
+                    backbone_vector=backbone_vector,
+                    use_default_bond=True)
+
+particle_ids=pmb.get_particle_id_map(object_name="R2")["all"]
+"""
+"R2":{"name": "R2",
+    "central_bead": "S1",
+    "side_chains": ["S2, S3"]}
+"""
+# Check that the particle properties are correct
+for pid in particle_ids:
+    particle=espresso_system.part.by_id(pid)
+    particle_name = pmb.df[pmb.df['particle_id']==pid and  pmb.df['pmb_type']=="particle"]["name"]
+    print(particle_name)
+    np.testing.assert_equal(actual=particle.type, 
+                                desired=type_map["S1"], 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.q, 
+                                desired=particle_parameters["S1"]["q"], 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.fix, 
+                                desired=[True]*3, 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.pos, 
+                                desired=particle_positions[pid], 
+                                verbose=True)
+

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -2,7 +2,6 @@
 # Import pyMBE and other libraries
 import pyMBE
 import numpy as np
-import warnings
 import espressomd
 
 # Create an instance of pyMBE library
@@ -10,28 +9,11 @@ pmb = pyMBE.pymbe_library(SEED=42)
 
 # The unit tests for define_particle are in lj_tests.py and set_particle_acidity
 
-def check_setup(input_parameters, object_name):
-    """
-    Checks if pyMBE stores in the pmb.df the input parameters  correctly.
-
-    Args:
-        input_parameters(`dict`): dictionary with the input parameters.
-    """
-    # Checks that the input parameters are stored properly
-    for index in pmb.df[pmb.df['name']==object_name].index:
-        for parameter_key in input_parameters.keys():
-            if parameter_key != "name":
-                np.testing.assert_equal(actual=pmb.df.loc[index, parameter_key].values[0].to("nm").magnitude, 
-                                        desired=input_parameters[parameter_key].to("nm").magnitude, 
-                                        verbose=True)    
-
 print("*** Unit test: check that define_particles() does not setup any particle if no parameters are provided ***")
 pmb.define_particles(parameters={})
 if not pmb.df.empty:
     RuntimeError("UNIT TEST FAILED")
 print("*** Unit test passed ***")
-
-
 
 print("*** Unit test: check that define_particles() defines a set of particles correctly ***")
 particle_parameters={"S1":{"name": "S1",
@@ -173,7 +155,7 @@ input_parameters={"name": "R2",
 np.testing.assert_raises(ValueError, pmb.create_particle, **input_parameters)
 print("*** Unit test passed ***")
 
-print("*** Unit test: check that create_residue() creates residues into the espresso_system with the properties defined in pmb.df  ***")
+print("*** Unit test: check that create_residue() creates a simple residue into the espresso_system with the properties defined in pmb.df  ***")
 
 bond_type = 'harmonic'
 bond = {'r_0'    : 0.4*pmb.units.nm,
@@ -185,35 +167,132 @@ pmb.define_default_bond(bond_type = bond_type,
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 central_bead_position=[[0,0,0]]
-backbone_vector=[1.,2.,3.]
+backbone_vector=np.array([1.,2.,3.])
 pmb.create_residue(name="R2",
                     espresso_system=espresso_system,
-                    number_of_residues=2,
                     central_bead_position=central_bead_position,
                     backbone_vector=backbone_vector,
                     use_default_bond=True)
 
 particle_ids=pmb.get_particle_id_map(object_name="R2")["all"]
-"""
-"R2":{"name": "R2",
-    "central_bead": "S1",
-    "side_chains": ["S2, S3"]}
-"""
+
 # Check that the particle properties are correct
 for pid in particle_ids:
     particle=espresso_system.part.by_id(pid)
-    particle_name = pmb.df[pmb.df['particle_id']==pid and  pmb.df['pmb_type']=="particle"]["name"]
-    print(particle_name)
+    particle_name = pmb.df[(pmb.df['particle_id']==pid) & (pmb.df['pmb_type']=="particle")]["name"].values[0]
     np.testing.assert_equal(actual=particle.type, 
-                                desired=type_map["S1"], 
+                                desired=type_map[particle_name], 
                                 verbose=True)
     np.testing.assert_equal(actual=particle.q, 
-                                desired=particle_parameters["S1"]["q"], 
+                                desired=particle_parameters[particle_name]["q"], 
                                 verbose=True)
-    np.testing.assert_equal(actual=particle.fix, 
-                                desired=[True]*3, 
+    # Check that the position are correct
+    # Central bead
+    if particle_name == "S1":
+        np.testing.assert_equal(actual=particle.pos, 
+                                desired=central_bead_position[0], 
                                 verbose=True)
-    np.testing.assert_equal(actual=particle.pos, 
-                                desired=particle_positions[pid], 
+    else: # Side chains should be in positions perpendicular to the backbone vector
+        np.testing.assert_almost_equal(actual=np.dot(particle.pos,backbone_vector), 
+                                desired=0, 
+                                verbose=True)
+    # Check that particles have the correct residue id
+    residue_id = pmb.df[(pmb.df['particle_id']==pid) & (pmb.df['pmb_type']=="particle")]["residue_id"].values[0]
+    np.testing.assert_equal(actual=residue_id, 
+                                desired=0, 
                                 verbose=True)
 
+# Check that particles are correctly bonded
+bonded_pairs=[]
+for bond_index in pmb.df[pmb.df['pmb_type']=="bond"].index:
+    particle_id1= pmb.df.loc[bond_index,"particle_id"].values[0]
+    particle_id2= pmb.df.loc[bond_index,"particle_id2"].values[0]
+    bonded_pair=[particle_id1,particle_id2]
+    bonded_pairs.append(bonded_pair)
+    bonded_in_espresso = False
+    for pid in bonded_pair:
+        for bond in espresso_system.part.by_id(pid).bonds[:]:
+            bond_object = bond[0]
+            partner_id  = bond[1]
+            if partner_id in bonded_pair:
+                bonded_in_espresso=True
+                # Test that the bond object is correctly stored in pyMBE
+                np.testing.assert_equal(actual=pmb.df.loc[bond_index,"bond_object"].values[0], 
+                            desired=bond_object, 
+                            verbose=True)
+    np.testing.assert_equal(actual=bonded_in_espresso, 
+                            desired=True, 
+                            verbose=True)
+
+np.testing.assert_equal(actual=bonded_pairs, 
+                        desired=[[2,3],[2,4]], 
+                        verbose=True)
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_residue() creates a nested residue into the espresso_system with the properties defined in pmb.df  ***")
+#pmb.destroy_pmb_object_in_system(name="R2",
+#                                 espresso_system=espresso_system)
+
+pmb.create_residue(name="R3",
+                    espresso_system=espresso_system,
+                    use_default_bond=True)
+
+particle_ids=pmb.get_particle_id_map(object_name="R3")["all"]
+
+# Check that the particle properties are correct
+for pid in particle_ids:
+    particle=espresso_system.part.by_id(pid)
+    particle_name = pmb.df[(pmb.df['particle_id']==pid) & (pmb.df['pmb_type']=="particle")]["name"].values[0]
+    np.testing.assert_equal(actual=particle.type, 
+                                desired=type_map[particle_name], 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.q, 
+                                desired=particle_parameters[particle_name]["q"], 
+                                verbose=True)
+    # Check that particles have the correct residue id
+    residue_id = pmb.df[(pmb.df['particle_id']==pid) & (pmb.df['pmb_type']=="particle")]["residue_id"].values[0]
+    np.testing.assert_equal(actual=residue_id, 
+                                desired=1, 
+                                verbose=True)
+
+# Check that particles are correctly bonded
+
+#print(pmb.df[(pmb.df['pmb_type']=="bond")])
+
+"""
+bonded_pairs=[]
+
+for bond_index in pmb.df[(pmb.df['pmb_type']=="bond")].index:
+    particle_id1= pmb.df.loc[bond_index,"particle_id"].values[0]
+    particle_id2= pmb.df.loc[bond_index,"particle_id2"].values[0]
+    bonded_pair=[particle_id1,particle_id2]
+    bonded_pairs.append(bonded_pair)
+    bonded_in_espresso = False
+    for pid in bonded_pair:
+        for bond in espresso_system.part.by_id(pid).bonds[:]:
+            bond_object = bond[0]
+            partner_id  = bond[1]
+            if partner_id in bonded_pair:
+                bonded_in_espresso=True
+                # Test that the bond object is correctly stored in pyMBE
+                np.testing.assert_equal(actual=pmb.df.loc[bond_index,"bond_object"].values[0], 
+                            desired=bond_object, 
+                            verbose=True)
+    np.testing.assert_equal(actual=bonded_in_espresso, 
+                            desired=True, 
+                            verbose=True)
+
+np.testing.assert_equal(actual=bonded_pairs, 
+                        desired=[[2,3],[2,4]], 
+                        verbose=True)
+"""
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_residue() raises a ValueError if the user provides the name of an object that is not a residue ***")
+input_parameters={"name": "S2",
+                 "espresso_system": espresso_system}
+np.testing.assert_raises(ValueError, pmb.create_residue, **input_parameters)
+print("*** Unit test passed ***")
+
+# Additional unit tests for define_molecule are in create_molecule_position_test

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -10,21 +10,21 @@ pmb = pyMBE.pymbe_library(SEED=42)
 # The unit tests for define_particle are in lj_tests.py and set_particle_acidity
 
 print("*** Unit test: check that define_particles() does not setup any particle if no parameters are provided ***")
-pmb.define_particles(parameters={})
-if not pmb.df.empty:
-    RuntimeError("UNIT TEST FAILED")
-print("*** Unit test passed ***")
+output = pmb.define_particles(parameters={})
+np.testing.assert_equal(actual=output, 
+                        desired=0, 
+                        verbose=True)
 
 print("*** Unit test: check that define_particles() defines a set of particles correctly ***")
 particle_parameters={"S1":{"name": "S1",
-                 "sigma":1*pmb.units.nm,
-                 "q":0},
-            "S2":{"name": "S2",
-                 "sigma":2*pmb.units.nm,
-                 "q": 1},
-            "S3":{"name": "S3",
-                 "sigma":3*pmb.units.nm,
-                 "q":2}}
+                            "sigma":1*pmb.units.nm,
+                            "q":0},
+                    "S2":{"name": "S2",
+                            "sigma":2*pmb.units.nm,
+                            "q": 1},
+                    "S3":{"name": "S3",
+                            "sigma":3*pmb.units.nm,
+                            "q":2}}
 pmb.define_particles(parameters=particle_parameters)
 
 for particle_name in particle_parameters.keys():
@@ -42,14 +42,14 @@ print("*** Unit test passed ***")
 print("*** Unit test: check that define_residue() stores the parameters correctly in pmb.df ***")
 
 residue_parameters={"R1":{"name": "R1",
-                 "central_bead": "S1",
-                 "side_chains": []},
-            "R2":{"name": "R2",
-                 "central_bead": "S1",
-                 "side_chains": ["S2","S3"]},
-            "R3":{"name": "R3",
-                 "central_bead": "S2",
-                 "side_chains": ["R1"]}}
+                        "central_bead": "S1",
+                        "side_chains": []},
+                    "R2":{"name": "R2",
+                        "central_bead": "S1",
+                        "side_chains": ["S2","S3"]},
+                    "R3":{"name": "R3",
+                        "central_bead": "S2",
+                        "side_chains": ["R2"]}}
 
 for parameter_set in residue_parameters.values():
     pmb.define_residue(**parameter_set)
@@ -135,7 +135,7 @@ for pid in particle_ids:
 print("*** Unit test passed ***")
 
 print("*** Unit test: check that create_particle() does not create any particle for number_of_particles <= 0  ***")
-
+starting_number_of_particles=len(espresso_system.part.all())
 pmb.create_particle(name="S1",
                     espresso_system=espresso_system,
                     number_of_particles=0)
@@ -144,8 +144,8 @@ pmb.create_particle(name="S1",
                     number_of_particles=-1)
 # If no particles have been created, only two particles should be in the system (from the previous test)
 np.testing.assert_equal(actual=len(espresso_system.part.all()), 
-                                desired=2, 
-                                verbose=True)
+                        desired=starting_number_of_particles, 
+                        verbose=True)
 print("*** Unit test passed ***")
 
 print("*** Unit test: check that create_particle() raises a ValueError if the user provides the name of an object that is not a particle ***")
@@ -207,7 +207,7 @@ bonded_pairs=[]
 for bond_index in pmb.df[pmb.df['pmb_type']=="bond"].index:
     particle_id1= pmb.df.loc[bond_index,"particle_id"].values[0]
     particle_id2= pmb.df.loc[bond_index,"particle_id2"].values[0]
-    bonded_pair=[particle_id1,particle_id2]
+    bonded_pair=frozenset([particle_id1,particle_id2])
     bonded_pairs.append(bonded_pair)
     bonded_in_espresso = False
     for pid in bonded_pair:
@@ -220,19 +220,20 @@ for bond_index in pmb.df[pmb.df['pmb_type']=="bond"].index:
                 np.testing.assert_equal(actual=pmb.df.loc[bond_index,"bond_object"].values[0], 
                             desired=bond_object, 
                             verbose=True)
+                np.testing.assert_equal(actual=pmb.df.loc[bond_index,"residue_id"].values[0], 
+                            desired=0, 
+                            verbose=True)
     np.testing.assert_equal(actual=bonded_in_espresso, 
                             desired=True, 
                             verbose=True)
 
-np.testing.assert_equal(actual=bonded_pairs, 
-                        desired=[[2,3],[2,4]], 
+np.testing.assert_equal(actual=frozenset(bonded_pairs), 
+                        desired=frozenset([frozenset([2,3]),frozenset([2,4])]), 
                         verbose=True)
 
 print("*** Unit test passed ***")
 
 print("*** Unit test: check that create_residue() creates a nested residue into the espresso_system with the properties defined in pmb.df  ***")
-#pmb.destroy_pmb_object_in_system(name="R2",
-#                                 espresso_system=espresso_system)
 
 pmb.create_residue(name="R3",
                     espresso_system=espresso_system,
@@ -258,15 +259,11 @@ for pid in particle_ids:
 
 # Check that particles are correctly bonded
 
-#print(pmb.df[(pmb.df['pmb_type']=="bond")])
-
-"""
 bonded_pairs=[]
-
-for bond_index in pmb.df[(pmb.df['pmb_type']=="bond")].index:
+for bond_index in pmb.df[(pmb.df['pmb_type']=="bond") & (pmb.df['residue_id']==1)].index:
     particle_id1= pmb.df.loc[bond_index,"particle_id"].values[0]
     particle_id2= pmb.df.loc[bond_index,"particle_id2"].values[0]
-    bonded_pair=[particle_id1,particle_id2]
+    bonded_pair=frozenset([particle_id1,particle_id2])
     bonded_pairs.append(bonded_pair)
     bonded_in_espresso = False
     for pid in bonded_pair:
@@ -279,14 +276,20 @@ for bond_index in pmb.df[(pmb.df['pmb_type']=="bond")].index:
                 np.testing.assert_equal(actual=pmb.df.loc[bond_index,"bond_object"].values[0], 
                             desired=bond_object, 
                             verbose=True)
+                np.testing.assert_equal(actual=pmb.df.loc[bond_index,"residue_id"].values[0], 
+                            desired=1, 
+                            verbose=True)
+
     np.testing.assert_equal(actual=bonded_in_espresso, 
                             desired=True, 
                             verbose=True)
 
-np.testing.assert_equal(actual=bonded_pairs, 
-                        desired=[[2,3],[2,4]], 
+np.testing.assert_equal(actual=frozenset(bonded_pairs), 
+                        desired=frozenset([frozenset([5,6]),
+                                            frozenset([6,7]),
+                                            frozenset([6,8])]), 
                         verbose=True)
-"""
+
 print("*** Unit test passed ***")
 
 print("*** Unit test: check that create_residue() raises a ValueError if the user provides the name of an object that is not a residue ***")
@@ -294,5 +297,117 @@ input_parameters={"name": "S2",
                  "espresso_system": espresso_system}
 np.testing.assert_raises(ValueError, pmb.create_residue, **input_parameters)
 print("*** Unit test passed ***")
-
+print("*** Unit test: check that create_residue() raises a ValueError if the any of the names in side_chains does not correspond to a previously defined particle ***")
+pmb.define_residue(name="test",
+               central_bead="S1",
+               side_chains=["test1"])
+input_parameters={"name": "test",
+                 "espresso_system": espresso_system}
+np.testing.assert_raises(ValueError, pmb.create_residue, **input_parameters)
+print("*** Unit test passed ***")
 # Additional unit tests for define_molecule are in create_molecule_position_test
+print("*** Unit test: check that create_molecule() creates a simple molecule into the espresso_system with the properties defined in pmb.df  ***")
+
+pmb.create_molecule(name="M2",
+                    number_of_molecules=2,
+                    espresso_system=espresso_system,
+                    use_default_bond=True)
+
+particle_ids=pmb.get_particle_id_map(object_name="M2")["all"]
+
+residue_ids={9: 2, 10: 3, 11: 3, 12: 3, 13: 4, 14: 4, 15: 4, 16: 4, # First molecule
+            17: 5, 18: 6, 19: 6, 20: 6, 21: 7, 22: 7, 23: 7, 24: 7} # Second molecule
+
+molecule_ids={9: 0, 10: 0, 11: 0, 12: 0, 13: 0, 14: 0, 15: 0, 16: 0, # First molecule
+              17: 1, 18: 1, 19: 1, 20: 1, 21: 1, 22: 1, 23: 1, 24: 1} # Second molecule
+
+# Check that the particle properties are correct
+for pid in particle_ids:
+    particle=espresso_system.part.by_id(pid)
+    particle_name = pmb.df[(pmb.df['particle_id']==pid) & (pmb.df['pmb_type']=="particle")]["name"].values[0]
+    np.testing.assert_equal(actual=particle.type, 
+                                desired=type_map[particle_name], 
+                                verbose=True)
+    np.testing.assert_equal(actual=particle.q, 
+                                desired=particle_parameters[particle_name]["q"], 
+                                verbose=True)
+    # Check that particles have the correct residue id
+    residue_id = pmb.df[(pmb.df['particle_id']==pid) & (pmb.df['pmb_type']=="particle")]["residue_id"].values[0]
+    np.testing.assert_equal(actual=residue_id, 
+                                desired=residue_ids[pid], 
+                                verbose=True)
+    # Check that particles have the correct molecule id
+    molecule_id = pmb.df[(pmb.df['particle_id']==pid) & (pmb.df['pmb_type']=="particle")]["molecule_id"].values[0]
+    np.testing.assert_equal(actual=molecule_id, 
+                                desired=molecule_ids[pid], 
+                                verbose=True)
+
+# Check that the molecules have the right residues
+for mol_id in [0,1]:
+    residue_list=[]
+    for res_index in pmb.df[(pmb.df['pmb_type']=="residue") & (pmb.df['molecule_id']==mol_id)].index:
+        resname=pmb.df.loc[res_index,"name"].values[0]
+        residue_list.append(resname)
+    np.testing.assert_equal(actual=frozenset(residue_list), 
+                            desired=frozenset(molecule_parameters["M2"]["residue_list"]), 
+                            verbose=True)
+
+bonded_pairs_ref={0: [frozenset([9,10]),
+                      frozenset([10,11]),
+                      frozenset([10,12]),
+                      frozenset([10,13]),
+                      frozenset([13,14]),
+                      frozenset([14,15]),
+                      frozenset([14,16])],
+                  1: [frozenset([17,18]),
+                      frozenset([18,19]),
+                      frozenset([18,20]),
+                      frozenset([18,21]),
+                      frozenset([21,22]),
+                      frozenset([22,23]),
+                      frozenset([22,24])]}
+
+# Check that particles are correctly bonded
+bonded_pairs={}
+for mol_id in [0,1]:
+    bonded_pairs[mol_id]=[]
+    for bond_index in pmb.df[(pmb.df['pmb_type']=="bond") & (pmb.df['molecule_id']==mol_id)].index:
+        particle_id1= pmb.df.loc[bond_index,"particle_id"].values[0]
+        particle_id2= pmb.df.loc[bond_index,"particle_id2"].values[0]
+        bonded_pair=frozenset([particle_id1,particle_id2])
+        bonded_pairs[mol_id].append(bonded_pair)
+        bonded_in_espresso = False
+        for pid in bonded_pair:
+            for bond in espresso_system.part.by_id(pid).bonds[:]:
+                bond_object = bond[0]
+                partner_id  = bond[1]
+                if partner_id in bonded_pair:
+                    bonded_in_espresso=True
+                    # Test that the bond object is correctly stored in pyMBE
+                    np.testing.assert_equal(actual=pmb.df.loc[bond_index,"bond_object"].values[0], 
+                                desired=bond_object, 
+                                verbose=True)
+        np.testing.assert_equal(actual=bonded_in_espresso, 
+                                desired=True, 
+                                verbose=True)
+    np.testing.assert_equal(actual=frozenset(bonded_pairs[mol_id]), 
+                            desired=frozenset(bonded_pairs_ref[mol_id]), 
+                            verbose=True)
+
+print("*** Unit test passed ***")
+print("*** Unit test: check that create_molecule() does not create any molcule for number_of_molecules <= 0  ***")
+
+starting_number_of_particles=len(espresso_system.part.all())
+pmb.create_molecule(name="M2",
+                    number_of_molecules=0,
+                    espresso_system=espresso_system,
+                    use_default_bond=True)
+pmb.create_molecule(name="M2",
+                    number_of_molecules=-1,
+                    espresso_system=espresso_system,
+                    use_default_bond=True)
+# If no particles have been created, only two particles should be in the system (from the previous test)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                        desired=starting_number_of_particles, 
+                        verbose=True)
+print("*** Unit test passed ***")

--- a/testsuite/globular_protein_tests.py
+++ b/testsuite/globular_protein_tests.py
@@ -28,7 +28,7 @@ def run_protein_test(script_path, test_pH_values, protein_pdb, rtol, atol,mode="
             run_command=[sys.executable, script_path, "--pdb", protein_pdb, "--pH", str(pH),
                          "--path_to_cg", f"parameters/globular_proteins/{protein_pdb}.vtf",
                          "--mode", "test", "--no_verbose", "--output", time_series_path]
-6            print(subprocess.list2cmdline(run_command))
+            print(subprocess.list2cmdline(run_command))
             subprocess.check_output(run_command)
         # Analyze all time series
         data=analysis.analyze_time_series(path_to_datafolder=time_series_path)
@@ -58,6 +58,14 @@ test_pH_values=[2,5,7]
 rtol=0.1 # relative tolerance
 atol=0.5 # absolute tolerance
 
+# Run test for 1F6S case
+protein_pdb = "1f6s"
+run_protein_test(script_path=script_path,
+                    test_pH_values=test_pH_values,
+                    protein_pdb=protein_pdb,
+                    rtol=rtol,
+                    atol=atol)   
+
 # Run test for 1BEB case
 protein_pdb = "1beb"
 run_protein_test(script_path=script_path,
@@ -66,10 +74,4 @@ run_protein_test(script_path=script_path,
                     rtol=rtol,
                     atol=atol)
 
-# Run test for 1F6S case
-protein_pdb = "1f6s"
-run_protein_test(script_path=script_path,
-                    test_pH_values=test_pH_values,
-                    protein_pdb=protein_pdb,
-                    rtol=rtol,
-                    atol=atol)   
+

--- a/testsuite/globular_protein_tests.py
+++ b/testsuite/globular_protein_tests.py
@@ -58,6 +58,14 @@ test_pH_values=[2,5,7]
 rtol=0.1 # relative tolerance
 atol=0.5 # absolute tolerance
 
+# Run test for 1BEB case
+protein_pdb = "1beb"
+run_protein_test(script_path=script_path,
+                    test_pH_values=test_pH_values,
+                    protein_pdb=protein_pdb,
+                    rtol=rtol,
+                    atol=atol)
+
 # Run test for 1F6S case
 protein_pdb = "1f6s"
 run_protein_test(script_path=script_path,
@@ -66,12 +74,5 @@ run_protein_test(script_path=script_path,
                     rtol=rtol,
                     atol=atol)   
 
-# Run test for 1BEB case
-protein_pdb = "1beb"
-run_protein_test(script_path=script_path,
-                    test_pH_values=test_pH_values,
-                    protein_pdb=protein_pdb,
-                    rtol=rtol,
-                    atol=atol)
 
 

--- a/testsuite/globular_protein_tests.py
+++ b/testsuite/globular_protein_tests.py
@@ -28,9 +28,7 @@ def run_protein_test(script_path, test_pH_values, protein_pdb, rtol, atol,mode="
             run_command=[sys.executable, script_path, "--pdb", protein_pdb, "--pH", str(pH),
                          "--path_to_cg", f"parameters/globular_proteins/{protein_pdb}.vtf",
                          "--mode", "test", "--no_verbose", "--output", time_series_path]
-            if protein_pdb == '1f6s':
-                run_command+=["--metal_ion_name","Ca", "--metal_ion_charge", "2"]
-            print(subprocess.list2cmdline(run_command))
+6            print(subprocess.list2cmdline(run_command))
             subprocess.check_output(run_command)
         # Analyze all time series
         data=analysis.analyze_time_series(path_to_datafolder=time_series_path)

--- a/testsuite/globular_protein_unit_tests.py
+++ b/testsuite/globular_protein_unit_tests.py
@@ -1,0 +1,40 @@
+import numpy as np 
+# Create an instance of pyMBE library
+import pyMBE
+pmb = pyMBE.pymbe_library(SEED=42)
+
+print("*** Unit test: Check  that check_aminoacid_key returns True for any latter valid in the one letter amino acid code***")
+valid_AA_keys=['V', 'I', 'L', 'E', 'Q', 'D', 'N', 'H', 'W', 'F', 'Y', 'R', 'K', 'S', 'T', 'M', 'A', 'G', 'P', 'C']
+for key in valid_AA_keys:
+    np.testing.assert_equal(actual=pmb.check_aminoacid_key(key=key), 
+                        desired=True, 
+                        verbose=True)
+print("*** Unit test passed ***\n")
+print("*** Unit test: Check  that check_aminoacid_key returns False for a key not valid in the one letter amino acid code ***")
+np.testing.assert_equal(actual=pmb.check_aminoacid_key(key="B"), 
+                        desired=False, 
+                        verbose=True)
+print("*** Unit test passed ***\n")
+
+print("*** Unit test: Check  that check_if_metal_ion returns True for any key corresponding to a supported metal ion ***")
+for key in pmb.get_metal_ions_charge_map().keys():
+    np.testing.assert_equal(actual=pmb.check_if_metal_ion(key=key), 
+                        desired=True, 
+                        verbose=True)
+print("*** Unit test passed ***\n")
+print("*** Unit test: Check  that check_if_metal_ion returns False for a key not corresponding to a supported metal ion ***")
+np.testing.assert_equal(actual=pmb.check_if_metal_ion(key="B"), 
+                        desired=False, 
+                        verbose=True)
+print("*** Unit test passed ***\n")
+
+print("*** Unit test: Check  that get_metal_ions_charge_map returns the correct charge map for metals ***")
+metal_charge_map = {"Ca": 2}
+pmb_metal_charge_map = pmb.get_metal_ions_charge_map()
+
+np.testing.assert_equal(actual=pmb_metal_charge_map, 
+                    desired=metal_charge_map, 
+                    verbose=True)
+print("*** Unit test passed ***\n")
+
+metal_charge_map = {"Ca": 2}

--- a/testsuite/parameter_test.py
+++ b/testsuite/parameter_test.py
@@ -1,9 +1,11 @@
 import pathlib
 import pyMBE
+import pandas as pd
+import numpy as np
 
 pmb = pyMBE.pymbe_library(SEED=42)
 
-print("*** Check that the different pKa sets are correctly formatted ***")
+print("*** Unit test: check that the different pKa sets are correctly formatted ***")
 
 pymbe_root = pathlib.Path(pyMBE.__file__).parent
 pka_root = pymbe_root / "parameters" / "pka_sets"
@@ -15,4 +17,97 @@ for path in pka_root.glob("*.json"):
     pmb.load_pka_set(path_to_pka,
                      verbose=False)
 
+print("*** Test passed ***")
+
+print("*** Unit test: check that the order to execute load_pka_set() and load_interaction_parameters does not change the resulting parameters in pmb.df ***")
+
+path_to_interactions=pmb.get_resource("parameters/peptides/Lunkad2021.json")
+path_to_pka=pmb.get_resource("parameters/pka_sets/Hass2015.json")
+
+# First order of loading parameters
+pmb.setup_df() # clear the pmb_df
+pmb.load_interaction_parameters (filename=path_to_interactions) 
+pmb.load_pka_set (filename=path_to_pka)
+df_1 = pmb.df.copy()
+df_1 = df_1.sort_values(by="name").reset_index(drop=True)
+# Drop espresso types (they depend on the order of loading)
+df_1 = df_1.drop(labels=('state_one', 'es_type'), axis=1).drop(labels=('state_two', 'es_type'), axis=1)
+# Drop bond_object  (assert_frame_equal does not process it well)
+df_1 = df_1.sort_index(axis=1).drop(labels="bond_object", axis=1)
+
+# Second order of loading parameters
+pmb.setup_df() # clear the pmb_df
+pmb.load_pka_set (filename=path_to_pka)
+pmb.load_interaction_parameters (filename=path_to_interactions) 
+df_2 = pmb.df.copy()
+df_2 = df_2.sort_values(by="name").reset_index(drop=True)
+# Drop espresso types (they depend on the order of loading)
+df_2 = df_2.drop(labels=('state_one', 'es_type'), axis=1).drop(labels=('state_two', 'es_type'), axis=1)
+# Drop bond_object  (assert_frame_equal does not process it well)
+df_2 = df_2.sort_index(axis=1).drop(labels="bond_object", axis=1)
+
+pd.testing.assert_frame_equal(df_1,df_2)
+
+print("*** Test passed ***")
+
+print("*** Unit test: check that  load_interaction_parameters loads FENE bonds correctly ***")
+pmb.setup_df() # clear the pmb_df
+path_to_interactions=pmb.get_resource("testsuite/test_parameters/test_FENE.json")
+pmb.load_interaction_parameters (filename=path_to_interactions) 
+
+expected_parameters = {'r_0'    : 0.4*pmb.units.nm,
+                        'k'      : 400 * pmb.units('reduced_energy / reduced_length**2'),
+                        'd_r_max': 0.8 * pmb.units.nm}
+reduced_units = {'r_0'    : 'reduced_length',
+                     'k'      : 'reduced_energy / reduced_length**2',
+                     'd_r_max': 'reduced_length'}
+parameters_in_df = pmb.df[pmb.df.pmb_type == "bond"].parameters_of_the_potential.values[0]
+
+for key in expected_parameters.keys():
+    np.testing.assert_equal(actual=parameters_in_df[key],
+                desired=expected_parameters[key].m_as(reduced_units[key]),
+                verbose=True)
+
+print("*** Test passed ***")
+print("*** Unit test: check that  load_interaction_parameters loads residue, molecule and peptide objects correctly ***")
+
+pmb.setup_df() # clear the pmb_df
+path_to_interactions=pmb.get_resource("testsuite/test_parameters/test_molecules.json")
+pmb.load_interaction_parameters (filename=path_to_interactions)
+
+expected_residue_parameters={"central_bead":  "A", "side_chains": ["B","C"] }
+expected_molecule_parameters={"residue_list":   ["R1","R1", "R1"]}
+expected_peptide_parameters= {"sequence":   ['K', 'K', 'K', 'K', 'K', 'D', 'D', 'D', 'D', 'D'], "model": "1beadAA" }
+
+# Check residue
+np.testing.assert_equal(actual=pmb.df[pmb.df.name == "R1"].central_bead.values[0],
+                desired=expected_residue_parameters["central_bead"],
+                verbose=True)
+
+np.testing.assert_equal(actual=frozenset(pmb.df[pmb.df.name == "R1"].side_chains.values[0]),
+                desired=frozenset(expected_residue_parameters["side_chains"]),
+                verbose=True)
+# Check molecule
+np.testing.assert_equal(actual=frozenset(pmb.df[pmb.df.name == "M1"].residue_list.values[0]),
+                desired=frozenset(expected_molecule_parameters["residue_list"]),
+                verbose=True)
+# Check peptide
+np.testing.assert_equal(actual=pmb.df[pmb.df.name == "P1"].sequence.values[0],
+                desired=expected_peptide_parameters["sequence"],
+                verbose=True)
+np.testing.assert_equal(actual=frozenset(pmb.df[pmb.df.name == "P1"].model.values[0]),
+                desired=frozenset(expected_peptide_parameters["model"]),
+                verbose=True)
+print("*** Test passed ***")
+print("*** Unit test: check that  load_interaction_parameters raises a ValueError if one loads a data set with an unknown pmb_type ***")
+pmb.setup_df() # clear the pmb_df
+path_to_interactions=pmb.get_resource("testsuite/test_parameters/test_non_valid_object.json")
+input_parameters={"filename":path_to_interactions}
+np.testing.assert_raises(ValueError, pmb.load_interaction_parameters, **input_parameters)
+print("*** Test passed ***")
+print("*** Unit test: check that  load_interaction_parameters raises a ValueError if one loads a bond not supported by pyMBE ***")
+pmb.setup_df() # clear the pmb_df
+path_to_interactions=pmb.get_resource("testsuite/test_parameters/test_non_valid_bond.json")
+input_parameters={"filename":path_to_interactions}
+np.testing.assert_raises(ValueError, pmb.load_interaction_parameters, **input_parameters)
 print("*** Test passed ***")

--- a/testsuite/peptide_tests.py
+++ b/testsuite/peptide_tests.py
@@ -59,7 +59,7 @@ atol=0.5 # absolute tolerance
 
 # Run test for K_5-D_5 case
 sequence="K"*5+"D"*5
-"""
+
 run_peptide_test(script_path=script_path,
                     test_pH_values=test_pH_values,
                     sequence=sequence,
@@ -74,7 +74,7 @@ run_peptide_test(script_path=script_path,
                     sequence=sequence,
                     rtol=rtol,
                     atol=atol)
-"""
+                    
 # Run test for histatin-5 case
 sequence="nDSHAKRHHGYKRKFHEKHHSHRGYc"
 run_peptide_test(script_path=script_path,

--- a/testsuite/peptide_tests.py
+++ b/testsuite/peptide_tests.py
@@ -59,6 +59,7 @@ atol=0.5 # absolute tolerance
 
 # Run test for K_5-D_5 case
 sequence="K"*5+"D"*5
+"""
 run_peptide_test(script_path=script_path,
                     test_pH_values=test_pH_values,
                     sequence=sequence,
@@ -67,12 +68,13 @@ run_peptide_test(script_path=script_path,
 
 # Run test for E_5-H_5 case
 sequence="E"*5+"H"*5
+
 run_peptide_test(script_path=script_path,
                     test_pH_values=test_pH_values,
                     sequence=sequence,
                     rtol=rtol,
                     atol=atol)
-
+"""
 # Run test for histatin-5 case
 sequence="nDSHAKRHHGYKRKFHEKHHSHRGYc"
 run_peptide_test(script_path=script_path,

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -25,12 +25,16 @@ pmb.define_particle(
 pmb.define_particle(
     name = "A",
     acidity = "acidic",
-    pka = 4)
+    pka = 4,
+    sigma = 0.3*pmb.units.nm,
+    epsilon = 1*pmb.units('reduced_energy'),)
     
 pmb.define_particle(
     name = "B",
     acidity = "basic",
-    pka = 9)
+    pka = 9,
+    sigma = 0.3*pmb.units.nm,
+    epsilon = 1*pmb.units('reduced_energy'),)
 
 #Define the residues
 pmb.define_residue(
@@ -93,7 +97,6 @@ with tempfile.TemporaryDirectory() as tmp_directory:
     # Write the pymbe DF to a csv file
     df_filename = f'{tmp_directory}/df-example_molecule.csv'
     pmb.write_pmb_df (filename = df_filename)
-
     # Read the same pyMBE df from a csv a load it in pyMBE
     read_df = pmb.read_pmb_df(filename = df_filename)
 

--- a/testsuite/setup_salt_ions_unit_tests.py
+++ b/testsuite/setup_salt_ions_unit_tests.py
@@ -1,0 +1,264 @@
+import numpy as np
+import espressomd
+# Create an instance of pyMBE library
+import pyMBE
+pmb = pyMBE.pymbe_library(SEED=42)
+
+# Define a set of ions
+pmb.define_particle(name="Na", 
+                    q=1)
+pmb.define_particle(name="Ca", 
+                    q=2)
+pmb.define_particle(name="Cl", 
+                    q=-1)
+pmb.define_particle(name="SO4", 
+                    q=-2)
+
+type_map=pmb.get_type_map()
+# System parameters
+c_salt_input = 0.01 * pmb.units.mol/ pmb.units.L
+N_SALT_ION_PAIRS = 50
+volume = N_SALT_ION_PAIRS/(pmb.N_A*c_salt_input)
+L = volume ** (1./3.) # Side of the simulation box
+
+# Create an instance of an espresso system
+espresso_system=espressomd.System (box_l = [L.to('reduced_length').magnitude]*3)
+espresso_system.setup_type_map(type_map.values())
+
+#### Unit tests for the added salt
+
+def check_salt_concentration(espresso_system,cation_name,anion_name,c_salt,N_SALT_ION_PAIRS, verbose=False):
+    charge_map=pmb.get_charge_map()
+    type_map=pmb.get_type_map()
+    espresso_system.setup_type_map(type_map.values())
+    c_salt_calculated = pmb.create_added_salt(espresso_system=espresso_system,
+                                            cation_name=cation_name,
+                                            anion_name=anion_name,
+                                            c_salt=c_salt_input,
+                                            verbose=verbose)
+
+    np.testing.assert_equal(espresso_system.number_of_particles(type_map[cation_name]),N_SALT_ION_PAIRS*abs(charge_map[type_map[anion_name]]))
+    np.testing.assert_equal(espresso_system.number_of_particles(type_map[anion_name]),N_SALT_ION_PAIRS*abs(charge_map[type_map[cation_name]]))
+    np.testing.assert_almost_equal(c_salt_calculated.m_as("mol/L"), c_salt_input.m_as("mol/L"))
+    espresso_system.part.clear()
+print("*** Unit test: test that create_added_salt works for a 1:1 salt (NaCl-like). Should print the added salt concentration and number of ions ***")
+check_salt_concentration(espresso_system=espresso_system,
+                        cation_name="Na",
+                        anion_name="Cl",
+                        c_salt=c_salt_input,
+                        N_SALT_ION_PAIRS=N_SALT_ION_PAIRS,
+                        verbose=True)
+print("*** Unit test passed***")
+print("*** Unit test: test that create_added_salt works for a 2:1 salt (CaCl_2-like) ***")
+check_salt_concentration(espresso_system=espresso_system,
+                        cation_name="Ca",
+                        anion_name="Cl",
+                        c_salt=c_salt_input,
+                        N_SALT_ION_PAIRS=N_SALT_ION_PAIRS)
+print("*** Unit test passed***")
+print("*** Unit test: test that create_added_salt works for a 1:2 salt (Na_2SO_4-like) ***")
+check_salt_concentration(espresso_system=espresso_system,
+                        cation_name="Na",
+                        anion_name="SO4",
+                        c_salt=c_salt_input,
+                        N_SALT_ION_PAIRS=N_SALT_ION_PAIRS)
+print("*** Unit test passed***")
+print("*** Unit test: test that create_added_salt works for a 2:2 salt (CaSO_4-like) ***")
+check_salt_concentration(espresso_system=espresso_system,
+                        cation_name="Ca",
+                        anion_name="SO4",
+                        c_salt=c_salt_input,
+                        N_SALT_ION_PAIRS=N_SALT_ION_PAIRS)
+print("*** Unit test passed***")
+print("*** Unit test: check that create_added_salt works for an input c_salt in [particle/lenght**3]. Should print the concentration and number of ions")
+c_salt_part=c_salt_input*pmb.N_A
+espresso_system.setup_type_map(type_map.values())
+c_salt_calculated = pmb.create_added_salt(espresso_system=espresso_system,
+                                            cation_name="Na",
+                                            anion_name="Cl",
+                                            c_salt=c_salt_part)
+np.testing.assert_equal(espresso_system.number_of_particles(type_map["Na"]),N_SALT_ION_PAIRS)
+np.testing.assert_equal(espresso_system.number_of_particles(type_map["Cl"]),N_SALT_ION_PAIRS)
+np.testing.assert_almost_equal(c_salt_calculated.m_as("reduced_length**-3"), c_salt_part.m_as("reduced_length**-3"))
+espresso_system.part.clear()
+
+print("*** Unit test: check that create_added_salt raises a ValueError if one provides a cation_name of an object that has been defined with a non-positive charge ***")
+input_parameters={"cation_name":"Cl",
+                    "anion_name":"SO4",
+                    "c_salt":c_salt_input,
+                   "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, pmb.create_added_salt, **input_parameters)
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_added_salt raises a ValueError if one provides a anion_name of an object that has been defined with a non-negative charge ***")
+input_parameters={"cation_name":"Na",
+                    "anion_name":"Ca",
+                    "c_salt":c_salt_input,
+                   "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, pmb.create_added_salt, **input_parameters)
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_added_salt raises a ValueError if one provides a c_salt with the wrong dimensionality ***")
+input_parameters={"cation_name":"Na",
+                    "anion_name":"Cl",
+                    "c_salt":1*pmb.units.nm,
+                   "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, pmb.create_added_salt, **input_parameters)
+print("*** Unit test passed ***")
+
+### Unit tests for the counter ions:
+
+
+def setup_molecules():
+    pmb.define_particle(name='0P',
+                            q=0)
+    pmb.define_particle(name='+1P',
+                        q=+1)
+    pmb.define_particle(name='-1P',
+                        q=-1)
+    pmb.define_residue(
+        name = 'R1',
+        central_bead = '0P',
+        side_chains = ['+1P']
+        )
+
+    pmb.define_residue(
+        name = 'R2',
+        central_bead = '0P',
+        side_chains = ['-1P']
+        )
+
+    bond_type = 'harmonic'
+    generic_bond_length=0.4 * pmb.units.nm
+    generic_harmonic_constant = 400 * pmb.units('reduced_energy / reduced_length**2')
+
+    harmonic_bond = {'r_0'    : generic_bond_length,
+                    'k'      : generic_harmonic_constant,
+                    }
+
+    pmb.define_default_bond(bond_type = bond_type, 
+                            bond_parameters = harmonic_bond)
+    # Add all bonds to espresso system
+    pmb.add_bonds_to_espresso(espresso_system=espresso_system)
+    molecule_name = 'positive_polyampholyte'
+    pmb.define_molecule(name=molecule_name, 
+                        residue_list = ['R1']*3+['R2']*2)
+
+    molecule_name = 'isoelectric_polyampholyte'
+    pmb.define_molecule(name=molecule_name, 
+                        residue_list = ['R1']*3+['R2']*3)
+
+    molecule_name = 'negative_polyampholyte'
+    pmb.define_molecule(name=molecule_name, 
+                        residue_list = ['R1']*2+['R2']*3)
+
+def test_counterions(molecule_name, cation_name, anion_name, espresso_system, expected_numbers,verbose=False):
+    setup_molecules()
+    pmb.create_molecule(name=molecule_name,
+                        number_of_molecules= 2,
+                        espresso_system=espresso_system,
+                        use_default_bond=True)
+    pmb.create_counterions(object_name=molecule_name,
+                            cation_name=cation_name,
+                            anion_name=anion_name,
+                            espresso_system=espresso_system,
+                            verbose=verbose)
+    espresso_system.setup_type_map(type_map.values())
+    np.testing.assert_equal(espresso_system.number_of_particles(type_map[cation_name]),expected_numbers[cation_name])
+    np.testing.assert_equal(espresso_system.number_of_particles(type_map[anion_name]),expected_numbers[anion_name])
+    pmb.destroy_pmb_object_in_system(espresso_system=espresso_system,
+                                    name=molecule_name)
+    espresso_system.part.clear()
+
+print("*** Unit test: check that create_counterions creates the right number of monovalent counter ions for a polyampholyte with positive net charge. Should print the number of ions. ***")
+
+test_counterions(molecule_name='positive_polyampholyte', 
+                cation_name="Na", 
+                anion_name="Cl", 
+                espresso_system=espresso_system, 
+                expected_numbers={"Na":4,
+                                  "Cl":6},
+                verbose=True)
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_counterions creates the right number of monovalent counter ions for a polyampholyte at its isoelectric point ***")
+
+test_counterions(molecule_name='isoelectric_polyampholyte', 
+                cation_name="Na", 
+                anion_name="Cl", 
+                espresso_system=espresso_system, 
+                expected_numbers={"Na":6,
+                                  "Cl":6})
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_counterions creates the right number of monovalent counter ions for a polyampholyte with a negative net charge ***")
+
+test_counterions(molecule_name='negative_polyampholyte', 
+                cation_name="Na", 
+                anion_name="Cl", 
+                espresso_system=espresso_system, 
+                expected_numbers={"Na":6,
+                                  "Cl":4})
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_counterions creates the right number of multivalent counter ions for a polyampholyte ***")
+
+test_counterions(molecule_name='negative_polyampholyte', 
+                cation_name="Ca", 
+                anion_name="Cl", 
+                espresso_system=espresso_system, 
+                expected_numbers={"Ca":3,
+                                  "Cl":4})
+
+print("*** Unit test passed ***")
+
+print("*** Unit test: check that create_counterions raises a ValueError if the charge number of the cation is not divisible by the negative charge of the polyampholyte ***")
+setup_molecules()
+pmb.create_molecule(name='isoelectric_polyampholyte',
+                        number_of_molecules= 1,
+                        espresso_system=espresso_system,
+                        use_default_bond=True)
+input_parameters={"cation_name":"Ca",
+                    "anion_name":"Cl",
+                    "object_name":'isoelectric_polyampholyte',
+                   "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, pmb.create_counterions, **input_parameters)
+print("*** Unit test passed ***")
+print("*** Unit test: check that create_counterions raises a ValueError if the charge number of the anion is not divisible by the positive charge of the polyampholyte ***")
+setup_molecules()
+input_parameters={"cation_name":"Na",
+                    "anion_name":"SO4",
+                    "object_name":'isoelectric_polyampholyte',
+                   "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, pmb.create_counterions, **input_parameters)
+pmb.destroy_pmb_object_in_system(espresso_system=espresso_system,
+                                    name='isoelectric_polyampholyte')
+
+print("*** Unit test passed ***")
+print("*** Unit test: check that no create_counterions does not create counterions for molecules with no charge")
+pmb.define_particle(name='0P',
+                        q=0)
+pmb.define_residue(
+    name = 'R0',
+    central_bead = '0P',
+    side_chains = []
+    )
+
+pmb.define_molecule(name='neutral_molecule', 
+                    residue_list = ['R0'])
+
+pmb.create_molecule(name='neutral_molecule',
+                    number_of_molecules= 1,
+                    espresso_system=espresso_system)
+pmb.create_counterions(object_name='neutral_molecule',
+                            cation_name="Na",
+                            anion_name="Cl",
+                            espresso_system=espresso_system,
+                            verbose=False)
+espresso_system.setup_type_map(type_map.values())
+np.testing.assert_equal(espresso_system.number_of_particles(type_map["Na"]),0)
+np.testing.assert_equal(espresso_system.number_of_particles(type_map["Cl"]),0)
+print("*** Unit test passed ***")

--- a/testsuite/setup_salt_ions_unit_tests.py
+++ b/testsuite/setup_salt_ions_unit_tests.py
@@ -34,12 +34,12 @@ def check_salt_concentration(espresso_system,cation_name,anion_name,c_salt,N_SAL
     c_salt_calculated = pmb.create_added_salt(espresso_system=espresso_system,
                                             cation_name=cation_name,
                                             anion_name=anion_name,
-                                            c_salt=c_salt_input,
+                                            c_salt=c_salt,
                                             verbose=verbose)
 
     np.testing.assert_equal(espresso_system.number_of_particles(type_map[cation_name]),N_SALT_ION_PAIRS*abs(charge_map[type_map[anion_name]]))
     np.testing.assert_equal(espresso_system.number_of_particles(type_map[anion_name]),N_SALT_ION_PAIRS*abs(charge_map[type_map[cation_name]]))
-    np.testing.assert_almost_equal(c_salt_calculated.m_as("mol/L"), c_salt_input.m_as("mol/L"))
+    np.testing.assert_almost_equal(c_salt_calculated.m_as("mol/L"), c_salt.m_as("mol/L"))
     espresso_system.part.clear()
 print("*** Unit test: test that create_added_salt works for a 1:1 salt (NaCl-like). Should print the added salt concentration and number of ions ***")
 check_salt_concentration(espresso_system=espresso_system,

--- a/testsuite/test_parameters/test_FENE.json
+++ b/testsuite/test_parameters/test_FENE.json
@@ -1,0 +1,10 @@
+{
+	"metadata": {
+		"summary": "Parameters for testing"
+	},
+	"data": {
+		"K": {"object_type":"particle", "name": "K", "sigma": {"value":0.35, "units":"nm"}, "epsilon":{"value":1, "units":"reduced_energy"}},
+		"CA": {"object_type":"particle", "name": "CA", "q":0, "sigma": {"value":0.35, "units":"nm"}, "epsilon":{"value":1, "units":"reduced_energy"}},
+			"bond_CA_K": {"object_type":"bond",  "bond_type": "FENE", "particle_pairs": [["CA","K"]] , "bond_parameters" : {"r_0"  : {"value":0.4, "units":"nm"},	"k"  : {"value": 400, "units": "reduced_energy / reduced_length**2"}, "d_r_max": {"value": 0.8, "units":  "nm"}}}
+		}
+}

--- a/testsuite/test_parameters/test_molecules.json
+++ b/testsuite/test_parameters/test_molecules.json
@@ -1,0 +1,11 @@
+{
+	"metadata": {
+		"summary": "Parameters for testing"
+	},
+	"data": {
+		"res": {"object_type":"residue", "name": "R1", "central_bead":  "A", "side_chains": ["B","C"] },
+		"mol": {"object_type":"molecule", "name": "M1", "residue_list":   ["R1","R1", "R1"] },
+		"pep": {"object_type":"peptide", "name": "P1", "sequence":   "KKKKKDDDDD", "model": "1beadAA" }
+		
+		}
+}

--- a/testsuite/test_parameters/test_non_valid_bond.json
+++ b/testsuite/test_parameters/test_non_valid_bond.json
@@ -1,0 +1,10 @@
+{
+	"metadata": {
+		"summary": "Parameters for testing"
+	},
+	"data": {
+		"K": {"object_type":"particle", "name": "K", "sigma": {"value":0.35, "units":"nm"}, "epsilon":{"value":1, "units":"reduced_energy"}},
+		"CA": {"object_type":"particle", "name": "CA", "q":0, "sigma": {"value":0.35, "units":"nm"}, "epsilon":{"value":1, "units":"reduced_energy"}},
+			"bond_CA_K": {"object_type":"bond",  "bond_type": "unknown", "particle_pairs": [["CA","K"]] , "bond_parameters" : {"r_0"  : {"value":0.4, "units":"nm"},	"k"  : {"value": 400, "units": "reduced_energy / reduced_length**2"}, "d_r_max": {"value": 0.8, "units":  "nm"}}}
+		}
+}

--- a/testsuite/test_parameters/test_non_valid_object.json
+++ b/testsuite/test_parameters/test_non_valid_object.json
@@ -1,0 +1,9 @@
+{
+	"metadata": {
+		"summary": "Parameters for testing"
+	},
+	"data": {
+		"pep": {"object_type":"unknown", "name": "P1", "sequence":   "KKKKKDDDDD", "model": "1beadAA" }
+		
+		}
+}


### PR DESCRIPTION
Quite dense PR, I would appreciate at least two reviewers. Thank you @mariusaarsten for the help while addressing this PR. Partially solves #58.

Bug fixes: 
- closes #59 
- Fixes a heavy bug introduced in #27. In that PR, we replaced `diameter` by `sigma`, but we did not correct the setup for the sample scripts with particles with different sizes. I have added a proper `offset` to keep the intended previous behaviur.
- Different behaviors were obtained depending on which order `pmb.load_pka_set`  and `pmb.load_interaction_parameters` were called. Now one gets consistent behavior independently of the order.
- `pmb.read_protein_vtf_in_df` returned the estimated diameter  `topology_dict["radius"]` instead than the radius
- Removes the Pandas warnings from `lib/create_cg_from_pdb.py`

Code improvements:
- I have deprecated the following protein-specific functions:
* [x] `pymbe_library.define_AA_particles_in_sequence()`
* [x] `pymbe_library.define_epsilon_value_of_particles()`
* [x] `pymbe_library.define_particles_parameter_from_dict()`
* [x] `pymbe_library.setup_particle_sigma()`
* [x] `pymbe_library.write_output_vtf_file()`
- I have merged them in a more general function to define the parameters of several particles  `pymbe_library.define_particles()`
- `pymbe_library.write_output_vtf_file()` was not really necesary since there already exists a built-in function in espresso that does the same job and furthermore the output vtf were not compatible with `visualization/vmd-traj.py`.
- I have removed the case-specific arguments from `samples/Beyer2024/globular_protein.py`. Now the setup of the metal ions is done automatically inside `define_protein`. I have also defined new functions `pymbe_library.get_metal_ions_charge_map()` and  `pymbe_library.check_if_metal_ion()` to deal with the metal ions to make easier later the perspective generalization that we discussed @paobtorres @jngrad 

New CI tests for the following functions (some of them very much needed):
* [x] `pymbe_library.calculate_net_charge()`
* [x] `pymbe_library.create_added_salt()`
* [x] `pymbe_library.create_counterions()`
* [x] `pymbe_library.load_interaction_parameters()` 
* [x] `pymbe_library.check_aminoacid_key()`
* [x] `pymbe_library.check_if_metal_ion()`
* [x] `pymbe_library.get_metal_ions_charge_map()`
* [x] `pymbe_library.define_particles()`
* [x]  `pymbe_library.define_particle()`
* [x]  `pymbe_library.define_residue()`
* [x]  `pymbe_library.define_molecule()`
* [x]  `pymbe_library.create_particle()`
* [x]  `pymbe_library.create_residue()`
* [x]  `pymbe_library.create_molecule()`

I ran the functional tests and they all pass. I also ran longer tests and the results seem pretty similar to the results in our publication.

Current coverage: 77% total, 70% in pymbe.py