### PR TITLE
Copyright

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,12 +1,14 @@
 pyMBE is maintained and developed by several authors from different institutions in collaboration.
 The following people have contributed to pyMBE:
 
-## Core developers
-- David Beyer (University of Stuttgart, Germany)
+## Admins
 - Pablo M. Blanco (Norwegian University of Science and Tecnology, Norway)
 - Jean-Noël Grad (University of Stuttgart, Germany)
-- Sebastian P. Pineda (Charles University, Czech Republic)
 - Peter Košovan (Charles University, Czech Republic)
+
+## Core developers
+- David Beyer (University of Stuttgart, Germany)
+- Sebastian P. Pineda (Charles University, Czech Republic)
 - Paola B. Torres (Universidad Tecnologica Nacional, Argentina)
 
 ## Contributors

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,23 @@
 #!/bin/bash
+
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2023-2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 .PHONY: sample
 .PHONY: visual 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,21 @@
 #!/bin/bash
-
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2023-2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2023-2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .PHONY: sample
 .PHONY: visual 

--- a/lib/analysis.py
+++ b/lib/analysis.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import pandas as pd
 import numpy as np

--- a/lib/analysis.py
+++ b/lib/analysis.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import pandas as pd

--- a/lib/create_cg_from_pdb.py
+++ b/lib/create_cg_from_pdb.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 import argparse

--- a/lib/create_cg_from_pdb.py
+++ b/lib/create_cg_from_pdb.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import sys
 import argparse
 import numpy as np

--- a/lib/handy_functions.py
+++ b/lib/handy_functions.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 def setup_electrostatic_interactions (units, espresso_system, kT, c_salt=None, solvent_permittivity=78.5, method='p3m', tune_p3m=True, accuracy=1e-3,verbose=True):
     """

--- a/lib/handy_functions.py
+++ b/lib/handy_functions.py
@@ -1,3 +1,20 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 def setup_electrostatic_interactions (units, espresso_system, kT, c_salt=None, solvent_permittivity=78.5, method='p3m', tune_p3m=True, accuracy=1e-3,verbose=True):
     """

--- a/maintainer/configure_venv.py
+++ b/maintainer/configure_venv.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2023-2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import argparse
 import sysconfig

--- a/maintainer/configure_venv.py
+++ b/maintainer/configure_venv.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2023-2024 pyMBE-dev team
+# 
+# Copyright (C) 2023-2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# This file is part of pyMBE.
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import argparse

--- a/maintainer/header_template_license.txt
+++ b/maintainer/header_template_license.txt
@@ -1,17 +1,17 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team  
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team  
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/maintainer/header_template_license.txt
+++ b/maintainer/header_template_license.txt
@@ -1,5 +1,5 @@
 #pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
+#Copyright (C) 2024 pyMBE-dev team  
 #
 #This file is part of pyMBE.
 #
@@ -15,22 +15,3 @@
 #
 #You should have received a copy of the GNU General Public License
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-import pathlib
-import pyMBE
-
-pmb = pyMBE.pymbe_library(SEED=42)
-
-print("*** Check that the different pKa sets are correctly formatted ***")
-
-pymbe_root = pathlib.Path(pyMBE.__file__).parent
-pka_root = pymbe_root / "parameters" / "pka_sets"
-
-for path in pka_root.glob("*.json"):
-    print(f"Checking {path.stem}")
-    path_to_pka = pmb.get_resource(path.relative_to(pymbe_root).as_posix())
-    assert pathlib.Path(path_to_pka) == path
-    pmb.load_pka_set(path_to_pka,
-                     verbose=False)
-
-print("*** Test passed ***")

--- a/maintainer/standarize_data.py
+++ b/maintainer/standarize_data.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2023-2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2023-2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/maintainer/standarize_data.py
+++ b/maintainer/standarize_data.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2023-2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 import numpy as np

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2023-2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2023-2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 import sys

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2023-2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import re
 import sys
 import ast

--- a/samples/Beyer2024/create_paper_data.py
+++ b/samples/Beyer2024/create_paper_data.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/samples/Beyer2024/create_paper_data.py
+++ b/samples/Beyer2024/create_paper_data.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 from lib import analysis

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 from tqdm import tqdm
 import espressomd

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 from tqdm import tqdm

--- a/samples/Beyer2024/peptide.py
+++ b/samples/Beyer2024/peptide.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Load espresso, sugar and other necessary libraries
 import os

--- a/samples/Beyer2024/peptide.py
+++ b/samples/Beyer2024/peptide.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Load espresso, sugar and other necessary libraries
 import os
 import espressomd

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #######################################################
 # Loading modules 

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #######################################################
 # Loading modules 
 #######################################################

--- a/samples/branched_polyampholyte.py
+++ b/samples/branched_polyampholyte.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Load espresso, pyMBE and other necessary libraries
 import os 
 import espressomd

--- a/samples/branched_polyampholyte.py
+++ b/samples/branched_polyampholyte.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Load espresso, pyMBE and other necessary libraries
 import os 

--- a/samples/peptide.py
+++ b/samples/peptide.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Load espresso, pyMBE and other necessary libraries
 import os 
 import espressomd

--- a/samples/peptide.py
+++ b/samples/peptide.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Load espresso, pyMBE and other necessary libraries
 import os 

--- a/samples/peptide_mixture_grxmc_ideal.py
+++ b/samples/peptide_mixture_grxmc_ideal.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #Load espresso, pyMBE and other necessary libraries
 import os 

--- a/samples/peptide_mixture_grxmc_ideal.py
+++ b/samples/peptide_mixture_grxmc_ideal.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #Load espresso, pyMBE and other necessary libraries
 import os 
 import espressomd

--- a/samples/plot_HH.py
+++ b/samples/plot_HH.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Plots the charge of a peptide with a given sequence using either a custom or reference set of pKa values
 
 import numpy as np

--- a/samples/plot_HH.py
+++ b/samples/plot_HH.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Plots the charge of a peptide with a given sequence using either a custom or reference set of pKa values
 

--- a/samples/salt_solution_gcmc.py
+++ b/samples/salt_solution_gcmc.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Load python modules
 import os 

--- a/samples/salt_solution_gcmc.py
+++ b/samples/salt_solution_gcmc.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Load python modules
 import os 
 import espressomd

--- a/testsuite/bond_tests.py
+++ b/testsuite/bond_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/testsuite/bond_tests.py
+++ b/testsuite/bond_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 import numpy as np

--- a/testsuite/calculate_net_charge_unit_test.py
+++ b/testsuite/calculate_net_charge_unit_test.py
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2024 pyMBE-dev team
+#
+# This file is part of pyMBE.
+#
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 import espressomd
 # Create an instance of pyMBE library

--- a/testsuite/cph_ideal_tests.py
+++ b/testsuite/cph_ideal_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 import sys

--- a/testsuite/cph_ideal_tests.py
+++ b/testsuite/cph_ideal_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np 
 import espressomd
 # Create an instance of pyMBE library

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np 
 import espressomd

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2024 pyMBE-dev team
+#
+# This file is part of pyMBE.
+#
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/testsuite/gcmc_tests.py
+++ b/testsuite/gcmc_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import sys
 import tempfile

--- a/testsuite/gcmc_tests.py
+++ b/testsuite/gcmc_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import sys

--- a/testsuite/generate_perpendicular_vectors_test.py
+++ b/testsuite/generate_perpendicular_vectors_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 import pyMBE

--- a/testsuite/generate_perpendicular_vectors_test.py
+++ b/testsuite/generate_perpendicular_vectors_test.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 import pyMBE
 from itertools import combinations

--- a/testsuite/globular_protein_tests.py
+++ b/testsuite/globular_protein_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/testsuite/globular_protein_tests.py
+++ b/testsuite/globular_protein_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 from lib import analysis

--- a/testsuite/globular_protein_unit_tests.py
+++ b/testsuite/globular_protein_unit_tests.py
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2024 pyMBE-dev team
+#
+# This file is part of pyMBE.
+#
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np 
 # Create an instance of pyMBE library
 import pyMBE

--- a/testsuite/grxmc_ideal_tests.py
+++ b/testsuite/grxmc_ideal_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 import sys

--- a/testsuite/grxmc_ideal_tests.py
+++ b/testsuite/grxmc_ideal_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/testsuite/henderson_hasselbalch_tests.py
+++ b/testsuite/henderson_hasselbalch_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 import pyMBE

--- a/testsuite/henderson_hasselbalch_tests.py
+++ b/testsuite/henderson_hasselbalch_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 import pyMBE
 pmb = pyMBE.pymbe_library(SEED=42)

--- a/testsuite/lj_tests.py
+++ b/testsuite/lj_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/testsuite/lj_tests.py
+++ b/testsuite/lj_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 import numpy as np

--- a/testsuite/parameter_test.py
+++ b/testsuite/parameter_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pathlib
 import pyMBE

--- a/testsuite/peptide_tests.py
+++ b/testsuite/peptide_tests.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import sys
 import tempfile

--- a/testsuite/peptide_tests.py
+++ b/testsuite/peptide_tests.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import sys

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import re 
 import ast
 import tempfile

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re 
 import ast

--- a/testsuite/seed_test.py
+++ b/testsuite/seed_test.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np 
 import espressomd
 import pyMBE

--- a/testsuite/seed_test.py
+++ b/testsuite/seed_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np 
 import espressomd

--- a/testsuite/serialization_test.py
+++ b/testsuite/serialization_test.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import io
 import json
 import contextlib

--- a/testsuite/serialization_test.py
+++ b/testsuite/serialization_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
 import json

--- a/testsuite/set_particle_acidity_test.py
+++ b/testsuite/set_particle_acidity_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import numpy as np

--- a/testsuite/set_particle_acidity_test.py
+++ b/testsuite/set_particle_acidity_test.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import numpy as np
 import pyMBE

--- a/testsuite/setup_salt_ions_unit_tests.py
+++ b/testsuite/setup_salt_ions_unit_tests.py
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2024 pyMBE-dev team
+#
+# This file is part of pyMBE.
+#
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 import espressomd
 # Create an instance of pyMBE library

--- a/testsuite/weak_polyelectrolyte_dialysis_test.py
+++ b/testsuite/weak_polyelectrolyte_dialysis_test.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import pyMBE and other libraries
 import pyMBE

--- a/testsuite/weak_polyelectrolyte_dialysis_test.py
+++ b/testsuite/weak_polyelectrolyte_dialysis_test.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Import pyMBE and other libraries
 import pyMBE
 from lib import analysis

--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### pyMBE : The python-based Molecule Builder for ESPResSo.\n",
+    "#### Copyright (C) 2023 - 2024 pyMBE-dev team\n",
+    "\n",
+    "This file is part of pyMBE.\n",
+    "\n",
+    "pyMBE is free software: you can redistribute it and/or modify\n",
+    "it under the terms of the GNU General Public License as published by\n",
+    "the Free Software Foundation, either version 3 of the License, or\n",
+    "(at your option) any later version.\n",
+    "\n",
+    "pyMBE is distributed in the hope that it will be useful,\n",
+    "but WITHOUT ANY WARRANTY; without even the implied warranty of\n",
+    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n",
+    "GNU General Public License for more details.\n",
+    "\n",
+    "You should have received a copy of the GNU General Public License\n",
+    "along with this program.  If not, see <http://www.gnu.org/licenses/>."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     " # pyMBE Tutorial: the Python-based Molecule Builder for ESPResSo.\n",
     "\n",
     "\n",
@@ -1202,7 +1225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.8.10"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -4,29 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### pyMBE : The python-based Molecule Builder for ESPResSo.\n",
-    "#### Copyright (C) 2023 - 2024 pyMBE-dev team\n",
-    "\n",
-    "This file is part of pyMBE.\n",
-    "\n",
-    "pyMBE is free software: you can redistribute it and/or modify\n",
-    "it under the terms of the GNU General Public License as published by\n",
-    "the Free Software Foundation, either version 3 of the License, or\n",
-    "(at your option) any later version.\n",
-    "\n",
-    "pyMBE is distributed in the hope that it will be useful,\n",
-    "but WITHOUT ANY WARRANTY; without even the implied warranty of\n",
-    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n",
-    "GNU General Public License for more details.\n",
-    "\n",
-    "You should have received a copy of the GNU General Public License\n",
-    "along with this program.  If not, see <http://www.gnu.org/licenses/>."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     " # pyMBE Tutorial: the Python-based Molecule Builder for ESPResSo.\n",
     "\n",
     "\n",

--- a/tutorials/solution_tutorial.ipynb
+++ b/tutorials/solution_tutorial.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### pyMBE : The python-based Molecule Builder for ESPResSo.\n",
+    "#### Copyright (C) 2023 - 2024 pyMBE-dev team\n",
+    "\n",
+    "This file is part of pyMBE.\n",
+    "\n",
+    "pyMBE is free software: you can redistribute it and/or modify\n",
+    "it under the terms of the GNU General Public License as published by\n",
+    "the Free Software Foundation, either version 3 of the License, or\n",
+    "(at your option) any later version.\n",
+    "\n",
+    "pyMBE is distributed in the hope that it will be useful,\n",
+    "but WITHOUT ANY WARRANTY; without even the implied warranty of\n",
+    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n",
+    "GNU General Public License for more details.\n",
+    "\n",
+    "You should have received a copy of the GNU General Public License\n",
+    "along with this program.  If not, see <http://www.gnu.org/licenses/>."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     " # pyMBE Tutorial Solution: Alternating copolymer.\n",
     "\n",
     "\n",
@@ -244,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.8.10"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/solution_tutorial.ipynb
+++ b/tutorials/solution_tutorial.ipynb
@@ -4,29 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### pyMBE : The python-based Molecule Builder for ESPResSo.\n",
-    "#### Copyright (C) 2023 - 2024 pyMBE-dev team\n",
-    "\n",
-    "This file is part of pyMBE.\n",
-    "\n",
-    "pyMBE is free software: you can redistribute it and/or modify\n",
-    "it under the terms of the GNU General Public License as published by\n",
-    "the Free Software Foundation, either version 3 of the License, or\n",
-    "(at your option) any later version.\n",
-    "\n",
-    "pyMBE is distributed in the hope that it will be useful,\n",
-    "but WITHOUT ANY WARRANTY; without even the implied warranty of\n",
-    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n",
-    "GNU General Public License for more details.\n",
-    "\n",
-    "You should have received a copy of the GNU General Public License\n",
-    "along with this program.  If not, see <http://www.gnu.org/licenses/>."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     " # pyMBE Tutorial Solution: Alternating copolymer.\n",
     "\n",
     "\n",

--- a/visualization/create_vmd_script.py
+++ b/visualization/create_vmd_script.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import glob
 import re

--- a/visualization/create_vmd_script.py
+++ b/visualization/create_vmd_script.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import glob
 import re
 import argparse

--- a/visualization/vmd-traj.py
+++ b/visualization/vmd-traj.py
@@ -1,20 +1,20 @@
-#pyMBE : The python-based Molecule Builder for ESPResSo.
-#Copyright (C) 2024 pyMBE-dev team
 #
-#This file is part of pyMBE.
+# Copyright (C) 2024 pyMBE-dev team
 #
-#pyMBE is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This file is part of pyMBE.
 #
-#pyMBE is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import math

--- a/visualization/vmd-traj.py
+++ b/visualization/vmd-traj.py
@@ -1,3 +1,21 @@
+#pyMBE : The python-based Molecule Builder for ESPResSo.
+#Copyright (C) 2024 pyMBE-dev team
+#
+#This file is part of pyMBE.
+#
+#pyMBE is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#pyMBE is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import math
 import re


### PR DESCRIPTION
Fixes #53 

List of changes:

I added the license header to all Python/Cython/Bash/C++/CUDA/Doxygen files in the pyMBE repository.

The template I used can be found at '/maintainer/header_template_license.txt', so anyone can copy and paste it when adding new Python/Cython/Bash/C++/CUDA/Doxygen files. However, we need to remember to update the year in subsequent years.