### PR TITLE
replace print_reduced_units by get_reduced_units

### DIFF
--- a/pyMBE.py
+++ b/pyMBE.py
@@ -2137,6 +2137,24 @@ class pymbe_library():
         radius_map  = pd.concat([state_one,state_two],axis=0).to_dict()  
         return radius_map
 
+    def get_reduced_units(self):
+        """
+        Returns the  current set of reduced units defined in pyMBE.
+
+        Returns:
+            reduced_units_text(`str`): text with information about the current set of reduced units.
+
+        """
+        unit_length=self.units.Quantity(1,'reduced_length')
+        unit_energy=self.units.Quantity(1,'reduced_energy')
+        unit_charge=self.units.Quantity(1,'reduced_charge')
+        reduced_units_text=f"""Current set of reduced units:
+                            {unit_length.to('nm'):.5g} = {unit_length} 
+                            {unit_energy.to('J'):.5g} = {unit_energy} 
+                            {unit_charge.to('C'):.5g} = {unit_charge} 
+                            Temperature: {(self.kT/self.Kb).to('K'):.5g}"""
+        return reduced_units_text
+
     def get_resource(self, path):
         '''
         Locate a file resource of the pyMBE package.
@@ -2293,19 +2311,7 @@ class pymbe_library():
         sequence = sequence.split(",")[1:-1]
         return sequence
 
-    def print_reduced_units(self):
-        """
-        Prints the  current set of reduced units defined in pyMBE.units.
-        """
-        print("\nCurrent set of reduced units:")
-        unit_length=self.units.Quantity(1,'reduced_length')
-        unit_energy=self.units.Quantity(1,'reduced_energy')
-        unit_charge=self.units.Quantity(1,'reduced_charge')
-        print(f"{unit_length.to('nm'):.5g} = {unit_length}")
-        print(f"{unit_energy.to('J'):.5g} = {unit_energy}")
-        print(f"{unit_charge.to('C'):.5g} = {unit_charge}")
-        print(f"Temperature: {(self.kT/self.Kb).to('K'):.5g}")
-        print()
+    
 
     def propose_unused_type(self):
         """
@@ -2703,7 +2709,7 @@ class pymbe_library():
         self.units.define(f'reduced_length = {unit_length}')
         self.units.define(f'reduced_charge = {unit_charge}')
         if verbose:        
-            self.print_reduced_units()
+            print(self.get_reduced_units())
         return
 
     def setup_cpH (self, counter_ion, constant_pH, exclusion_range=None, pka_set=None, use_exclusion_radius_per_type = False):

--- a/pyMBE.py
+++ b/pyMBE.py
@@ -2148,11 +2148,12 @@ class pymbe_library():
         unit_length=self.units.Quantity(1,'reduced_length')
         unit_energy=self.units.Quantity(1,'reduced_energy')
         unit_charge=self.units.Quantity(1,'reduced_charge')
-        reduced_units_text=f"""Current set of reduced units:
-                            {unit_length.to('nm'):.5g} = {unit_length} 
-                            {unit_energy.to('J'):.5g} = {unit_energy} 
-                            {unit_charge.to('C'):.5g} = {unit_charge} 
-                            Temperature: {(self.kT/self.Kb).to('K'):.5g}"""
+        reduced_units_text = "\n".join(["Current set of reduced units:",
+                                       f"{unit_length.to('nm'):.5g} = {unit_length}",
+                                       f"{unit_energy.to('J'):.5g} = {unit_energy}",
+                                       f"{unit_charge.to('C'):.5g} = {unit_charge}",
+                                       f"Temperature: {(self.kT/self.Kb).to('K'):.5g}"
+                                        ])   
         return reduced_units_text
 
     def get_resource(self, path):

--- a/testsuite/serialization_test.py
+++ b/testsuite/serialization_test.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import io
 import json
-import contextlib
 import unittest as ut
 import numpy as np
 import pandas as pd
@@ -53,7 +51,7 @@ class Serialization(ut.TestCase):
         self.assertEqual(params_out, params_ref)
 
     def test_pint_units(self):
-        ref_output = f"""Current set of reduced units:
+        ref_output =  """Current set of reduced units:
                             0.355 nanometer = 1 reduced_length 
                             4.1164e-21 joule = 1 reduced_energy 
                             1.6022e-19 coulomb = 1 reduced_charge 

--- a/testsuite/serialization_test.py
+++ b/testsuite/serialization_test.py
@@ -51,11 +51,12 @@ class Serialization(ut.TestCase):
         self.assertEqual(params_out, params_ref)
 
     def test_pint_units(self):
-        ref_output =  """Current set of reduced units:
-                            0.355 nanometer = 1 reduced_length 
-                            4.1164e-21 joule = 1 reduced_energy 
-                            1.6022e-19 coulomb = 1 reduced_charge 
-                            Temperature: 298.15 kelvin"""
+        ref_output =  "\n".join(["Current set of reduced units:",
+                                 "0.355 nanometer = 1 reduced_length",
+                                 "4.1164e-21 joule = 1 reduced_energy",
+                                 "1.6022e-19 coulomb = 1 reduced_charge",
+                                 "Temperature: 298.15 kelvin"
+                                ]) 
         pmb = pyMBE.pymbe_library(SEED=42)
         reduced_units = pmb.get_reduced_units()
         self.assertEqual(reduced_units, ref_output)

--- a/testsuite/serialization_test.py
+++ b/testsuite/serialization_test.py
@@ -53,17 +53,14 @@ class Serialization(ut.TestCase):
         self.assertEqual(params_out, params_ref)
 
     def test_pint_units(self):
-        ref_output = [
-            "Current set of reduced units:",
-            "0.355 nanometer = 1 reduced_length",
-            "4.1164e-21 joule = 1 reduced_energy",
-            "1.6022e-19 coulomb = 1 reduced_charge",
-            "Temperature: 298.15 kelvin",
-        ]
+        ref_output = f"""Current set of reduced units:
+                            0.355 nanometer = 1 reduced_length 
+                            4.1164e-21 joule = 1 reduced_energy 
+                            1.6022e-19 coulomb = 1 reduced_charge 
+                            Temperature: 298.15 kelvin"""
         pmb = pyMBE.pymbe_library(SEED=42)
-        with contextlib.redirect_stdout(io.StringIO()) as f:
-            pmb.print_reduced_units()
-        self.assertEqual(f.getvalue().strip("\n").split("\n"), ref_output)
+        reduced_units = pmb.get_reduced_units()
+        self.assertEqual(reduced_units, ref_output)
 
 
 if __name__ == "__main__":

--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -91,7 +91,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb.print_reduced_units()"
+    "reduced_unit_set = get_reduced_units()\n",
+    "print(reduced_unit_set)"
    ]
   },
   {
@@ -1202,7 +1203,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Replaces `print_reduced_units` by `get_reduced_units`:
- The user now gets a string with the information about the current set of reduced units instead of having it printed to screen.
- This gives the user additional flexibility to handle this information: can be either printed to screen or elsewhere.