### PR TITLE
no folder `reference_parameters`

### DIFF
--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -1037,7 +1037,7 @@
     "* `1beadAA`, where the aminoacid is represented by one single bead.\n",
     "* `2beadAA`, where the aminoacid is represented by two beads (backbone and side-chain). \n",
     "\n",
-    "We provide reference parameters in the folder (`reference_parameters`) which can be loaded into pyMBE. The peptide sequence should be provided as a str composed either by the list of the one letter code or the list of the three letter code of the corresponding aminoacids. For example, the two possible ways to provide the peptide Cysteine$_3$ - Glutamic acid$_2$ - Histidine$_4$ - Valine are:\n",
+    "We provide reference parameters in the folder (`parameters`) which can be loaded into pyMBE. The peptide sequence should be provided as a str composed either by the list of the one letter code or the list of the three letter code of the corresponding aminoacids. For example, the two possible ways to provide the peptide Cysteine$_3$ - Glutamic acid$_2$ - Histidine$_4$ - Valine are:\n",
     "\n",
     "* one letter code: 'CCCEEHHHHV'\n",
     "* three letter code: 'CYS-CYS-CYS-GLU-GLU-HIS-HIS-HIS-HIS-VAL'"


### PR DESCRIPTION
In the [tutorial notebook](tutorials/pyMBE_tutorial.ipynb) under **How to create peptides** there is a reference to `reference_parameteres` a folder which does not exist in the repo. I guess you mean the folder `parameters` but I could be wrong.