### PR TITLE
Code duplication

### DIFF
--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -1074,9 +1074,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb.load_interaction_parameters (filename = pmb.get_resource('parameters/peptides/Lunkad2021.json'))\n",
-    "pmb.load_interaction_parameters (filename = pmb.get_resource('parameters/peptides/Lunkad2021.json'))\n",
-    "pmb.add_bonds_to_espresso (espresso_system = espresso_system)"
+    "pmb.load_interaction_parameters(filename = pmb.get_resource('parameters/peptides/Lunkad2021.json'))\n",
+    "pmb.add_bonds_to_espresso(espresso_system = espresso_system)"
    ]
   },
   {


### PR DESCRIPTION
In the second peptide code cell `pmb.load_interaction_parameters(filename = pmb.get_resource('parameters/peptides/Lunkad2021.json'))` appeared twice.