### PR TITLE
Remove  global state variables 

### DIFF
--- a/pyMBE.py
+++ b/pyMBE.py
@@ -77,7 +77,6 @@ class pymbe_library():
         self.N_A=scipy.constants.N_A / self.units.mol
         self.kB=scipy.constants.k * self.units.J / self.units.K
         self.e=scipy.constants.e * self.units.C
-        self.Kw=1e-14*self.units.mol**2 / (self.units.l**2)
         self.set_reduced_units(unit_length=unit_length, 
                                unit_charge=unit_charge,
                                temperature=temperature, 
@@ -2716,12 +2715,14 @@ class pymbe_library():
             temperature = 298.15 * self.units.K
         if unit_charge is None:
             unit_charge = scipy.constants.e * self.units.C
+        if Kw is None:
+            Kw = 1e-14
         # Sanity check
         variables=[unit_length,temperature,unit_charge]
         dimensionalities=["[length]","[temperature]","[charge]"]
         for variable,dimensionality in zip(variables,dimensionalities):
             self.check_dimensionality(variable,dimensionality)
-            
+        self.Kw=Kw*self.units.mol**2 / (self.units.l**2)
         self.kT=temperature*self.kB
         self.units._build_cache()
         self.units.define(f'reduced_energy = {self.kT} ')

--- a/testsuite/CTestTestfile.cmake
+++ b/testsuite/CTestTestfile.cmake
@@ -48,6 +48,7 @@ pymbe_add_test(PATH gcmc_tests.py LABELS long)
 
 # unit tests
 pymbe_add_test(PATH serialization_test.py)
+pymbe_add_test(PATH test_global_variables.py)
 pymbe_add_test(PATH lj_tests.py)
 pymbe_add_test(PATH set_particle_acidity_test.py)
 pymbe_add_test(PATH bond_tests.py)

--- a/testsuite/create_molecule_position_test.py
+++ b/testsuite/create_molecule_position_test.py
@@ -22,7 +22,7 @@ import espressomd
 import pyMBE
 pmb = pyMBE.pymbe_library(seed=42)
 
-print("***create_molecule with input position list unit test ***")
+print("*** Create_molecule with input position list unit test ***")
 print("*** Unit test: Check that the positions of the central bead of the first residue in the generated molecules are equal to the input positions ***")
 # Simulation parameters
 pmb.set_reduced_units(unit_length=0.4*pmb.units.nm,

--- a/testsuite/test_global_variables.py
+++ b/testsuite/test_global_variables.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2024 pyMBE-dev team
+#
+# This file is part of pyMBE.
+#
+# pyMBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyMBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pyMBE
+import numpy as np
+
+# Test that two different instances of pyMBE do not share the same memory address for their global attributes
+pmb1 = pyMBE.pymbe_library(seed=42)
+pmb2 = pyMBE.pymbe_library(seed=43)
+np.testing.assert_raises(AssertionError,
+                        np.testing.assert_equal,
+                        id(pmb1.units),
+                        id(pmb2.units))
+
+# Test that redefining the system of reduced units does not create a new pint.UnitRegistry
+
+## Define a variables in the old unit registry
+nm_length_1=pmb1.units.Quantity(1,"nm")
+
+## Change the system of reduced units
+pmb1.set_reduced_units(unit_length=0.4*pmb1.units.nm)
+
+## Define variable in the new unit registry
+nm_length_2=pmb1.units.Quantity(2,"nm")
+
+## operations between old and new quantities should work normally 
+np.testing.assert_equal((nm_length_1+nm_length_2).m_as("nm"), 
+                        (pmb1.units.Quantity(3,"nm").m_as("nm")))
+                        
+
+# Test that set_reduced_units raises a ValueError if the wrong unit is provided
+input_parameters={"unit_length": pmb1.units.Quantity(1, "J")}                      
+
+np.testing.assert_raises(ValueError,
+                        pmb1.set_reduced_units,
+                        **input_parameters)


### PR DESCRIPTION
Solves #60 

- Removes global state variables, instead they are now created by the constructor of  `pyMBE.pymbe_library`.
- `pmb.set_reduced_units()` now redefines the reduced units instead of creating a new instance of `pint.UnitRegistry`. Therefore, the user can do operations between objects defining before and after changing the set of reduced units without getting a `ValueError`
- `pmb.set_reduced_units()` now checks that the arguments provided by the user have the right dimensionality.
- The constants stored as attributes in `pyMBE.pymbe_library` are not rewritten anymore after calling `pmb.set_reduced_units()` 
