### PR TITLE
Update changelog and switch from os.makedirs to Path().mkdir()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Switched from `os.makedirs` to `Path().mkdir()` to prevent ocasional failure of the scripts when running them in paralel. (#91)
+- `pmb.set_reduced_units()` now redefines the reduced units instead of creating a new instance of `pint.UnitRegistry`. Therefore, the user can do operations between objects defining before and after changing the set of reduced units without getting a `ValueError` (#89)
+- `pmb.set_reduced_units()` now checks that the arguments provided by the user have the right dimensionality. (#89)
+- The constants stored as attributes in `pyMBE.pymbe_library` are now using their values stabilished in the 2019 SI. The value is taken directly from `scipy.constants` instead of being a hard-coded constant. (#86)
+- Switched to Ctest for testing, allowing to run the tests on paralel (#87)
+
+### Added
+- Unit testing for reaction methods (#86)
+
+### Fixed
+- Removed global state variables, instead they are now created by the constructor of `pyMBE.pymbe_library`. This prevents two instances of the pyMBE library to share the same memory address for their attributes. (#89)
+- Required Python dependency versions compatible with ESPResSo 4.2 (#84)
+- Fixed several deprecated paths and function names in `tutorials/pyMBE_tutorial.ipynb`. (#77, #78, #79, #80, #81)
+
 ## [0.8.0] - 2024-06-18
 
 ### Added

--- a/samples/Beyer2024/create_paper_data.py
+++ b/samples/Beyer2024/create_paper_data.py
@@ -19,7 +19,7 @@
 # Import pyMBE and other libraries
 import pyMBE
 from lib import analysis
-import os
+from pathlib import Path
 import sys
 import numpy as np
 import argparse 
@@ -114,8 +114,8 @@ data=analysis.analyze_time_series(path_to_datafolder=time_series_folder_path)
 
 # Store mean values and other statistics
 data_path=pmb.get_resource("samples/Beyer2024/")+"data"
-if not os.path.exists(data_path):
-    os.makedirs(data_path)
+Path(data_path).mkdir(parents=True, 
+                       exist_ok=True)
 data.to_csv(f"{data_path}/fig{fig_label}.csv")
 
 if plot:
@@ -341,8 +341,8 @@ if plot:
 
     # Save plot
     fig_path=pmb.get_resource("samples/Beyer2024")+"/figs"
-    if not os.path.exists(fig_path):
-        os.makedirs(fig_path)
+    Path(fig_path).mkdir(parents=True, 
+                       exist_ok=True)
     plt.legend(frameon=False, loc="lower left", fontsize=9, bbox_to_anchor=(0,1.02,1,0.2), mode="expand", borderaxespad=0, ncol=2)
     plt.savefig(f"{fig_path}/{fig_label}.pdf", 
                 bbox_inches='tight')

--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+from pathlib import Path
 from tqdm import tqdm
 import espressomd
 import argparse
@@ -123,8 +123,8 @@ WCA = True
 Electrostatics = True
 
 # The trajectories of the simulations will be stored using espresso built-up functions in separed files in the folder 'frames'
-if not os.path.exists('./frames'):
-    os.makedirs('./frames')
+Path("./frames").mkdir(parents=True, 
+                       exist_ok=True)
 
 espresso_system = espressomd.System(box_l=[Box_L.to('reduced_length').magnitude] * 3)
 espresso_system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative()
@@ -303,8 +303,8 @@ data_path = args.output
 if data_path is None:
     data_path=pmb.get_resource(path="samples/Beyer2024/")+"/time_series/globular_protein"
 
-if not os.path.exists(data_path):
-    os.makedirs(data_path)
+Path(data_path).mkdir(parents=True, 
+                       exist_ok=True)
     
 time_series=pd.DataFrame(time_series)
 filename=analysis.built_output_name(input_dict=inputs)

--- a/samples/Beyer2024/peptide.py
+++ b/samples/Beyer2024/peptide.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Load espresso, sugar and other necessary libraries
-import os
+# Load espresso, pyMBE and other necessary libraries
+from pathlib import Path
 import espressomd
 import pandas as pd
 import argparse
@@ -236,8 +236,8 @@ data_path = args.output
 if data_path is None:
     data_path=pmb.get_resource(path="samples/Beyer2024")+"/time_series/peptides"
 
-if not os.path.exists(data_path):
-    os.makedirs(data_path)
+Path(data_path).mkdir(parents=True, 
+                       exist_ok=True)
 
 time_series=pd.DataFrame(time_series)
 filename=analysis.built_output_name(input_dict=inputs)

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -21,8 +21,8 @@
 #######################################################
 
 # Load python modules
-import os 
 import espressomd
+from pathlib import Path
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
@@ -249,8 +249,8 @@ data_path = args.output
 if data_path is None:
     data_path=pmb.get_resource(path="samples/Beyer2024")+"/time_series/grxmc"
 
-if not os.path.exists(data_path):
-    os.makedirs(data_path)
+Path(data_path).mkdir(parents=True, 
+                       exist_ok=True)
 
 time_series=pd.DataFrame(time_series)
 filename=analysis.built_output_name(input_dict=inputs)

--- a/samples/branched_polyampholyte.py
+++ b/samples/branched_polyampholyte.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Load espresso, pyMBE and other necessary libraries
-import os 
+from pathlib import Path
 import espressomd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -44,8 +44,8 @@ from lib.handy_functions import setup_langevin_dynamics
 from lib.analysis import block_analyze
 
 # The trajectories of the simulations will be stored using espresso built-up functions in separed files in the folder 'frames'
-if not os.path.exists('./frames'):
-    os.makedirs('./frames')
+Path("./frames").mkdir(parents=True, 
+                       exist_ok=True)
 
 # Simulation parameters
 pmb.set_reduced_units(unit_length=0.4*pmb.units.nm)

--- a/samples/peptide.py
+++ b/samples/peptide.py
@@ -17,12 +17,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Load espresso, pyMBE and other necessary libraries
-import os 
 import espressomd
 import numpy as np
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 from espressomd.io.writer import vtf
+from pathlib import Path
 import pyMBE
 
 # Create an instance of pyMBE library
@@ -35,8 +35,8 @@ from lib.handy_functions import setup_langevin_dynamics
 from lib.analysis import block_analyze
 
 # The trajectories of the simulations will be stored using espresso built-up functions in separed files in the folder 'frames'
-if not os.path.exists('./frames'):
-    os.makedirs('./frames')
+Path("./frames").mkdir(parents=True, 
+                       exist_ok=True)
 
 # Simulation parameters
 pmb.set_reduced_units(unit_length=0.4*pmb.units.nm)

--- a/samples/peptide_mixture_grxmc_ideal.py
+++ b/samples/peptide_mixture_grxmc_ideal.py
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #Load espresso, pyMBE and other necessary libraries
-import os 
 import espressomd
+from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -48,8 +48,8 @@ if args.mode not in valid_modes:
     raise ValueError(f"Mode {args.mode} is not currently supported, valid modes are {valid_modes}")
 
 # The trajectories of the simulations will be stored using espresso built-up functions in separed files in the folder 'frames'
-if not os.path.exists('./frames'):
-    os.makedirs('./frames')
+Path("./frames").mkdir(parents=True, 
+                       exist_ok=True)
 
 #Import functions from handy_functions script 
 from lib.analysis import block_analyze

--- a/samples/salt_solution_gcmc.py
+++ b/samples/salt_solution_gcmc.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Load python modules
-import os 
+from pathlib import Path
 import espressomd
 import numpy as np
 import pandas as pd
@@ -190,8 +190,8 @@ data_path = args.output
 if data_path is None:
     data_path=pmb.get_resource(path="samples/Beyer2024")+"/time_series/gcmc"
 
-if not os.path.exists(data_path):
-    os.makedirs(data_path)
+Path(data_path).mkdir(parents=True, 
+                       exist_ok=True)
 
 time_series=pd.DataFrame(time_series)
 filename=analysis.built_output_name(input_dict=inputs)


### PR DESCRIPTION
The last periodic `samples` job failed with the following error:
```bash
Traceback (most recent call last):
  File "/home/runner/work/pyMBE/pyMBE/samples/Beyer2024/globular_protein.py", line 127, in <module>
    os.makedirs('./frames')
  File "<frozen os>", line 225, in makedirs
FileExistsError: [Errno 17] File exists: './frames'
E
======================================================================
ERROR: test_globular_protein (__main__.Test.test_globular_protein)
----------------------------------------------------------------------
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
           ^^^^^^^^^^^^^^^^
  File "/home/runner/work/pyMBE/pyMBE/testsuite/globular_protein_tests.py", line 52, in kernel
    subprocess.check_output(run_command)
  File "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/runner/work/pyMBE/pyMBE/venv/bin/python3.11', PosixPath('/home/runner/work/pyMBE/pyMBE/samples/Beyer2024/globular_protein.py'), '--pdb', '1f6s', '--pH', '2', '--path_to_cg', 'parameters/globular_proteins/1f6s.vtf', '--mode', 'test', '--no_verbose', '--output', '/tmp/tmpbq6xb_mf']' returned non-zero exit status 1.
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/work/pyMBE/pyMBE/testsuite/globular_protein_tests.py", line 63, in test_globular_protein
    results = dict(pool.map(kernel, tasks, chunksize=1))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/multiprocessing/pool.py", line 367, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/multiprocessing/pool.py", line 774, in get
    raise self._value
subprocess.CalledProcessError: Command '['/home/runner/work/pyMBE/pyMBE/venv/bin/python3.11', PosixPath('/home/runner/work/pyMBE/pyMBE/samples/Beyer2024/globular_protein.py'), '--pdb', '1f6s', '--pH', '2', '--path_to_cg', 'parameters/globular_proteins/1f6s.vtf', '--mode', 'test', '--no_verbose', '--output', '/tmp/tmpbq6xb_mf']' returned non-zero exit status 1.

The following tests FAILED:
	  1 - globular_protein_tests (Failed)
``` 
When I re-ran the `samples` job manually on Github it passed and all tests passed locally on my desk computer as well. I suspect that the issue was in the following lines:

```python
if not os.path.exists('./frames'):
    os.makedirs('./frames')
```
which can result on an error when executing a script with multiple threats if it happens that two (or more) processes execute the first line before the first threat creates a folder in the following one. To avoid this issue I have decided to switch to pathlib instead:

```python
Path("./frames").mkdir(parents=True,
                       exist_ok=True)
```
I believe that this should solve the issue, although I was not able to reproduce the initial error. I took the chance also to update our changelog.

