### PR TITLE
move_protein not boolian in globular_protein.py

### DIFF
--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -55,7 +55,7 @@ parser.add_argument('--path_to_cg',
                     required= True,  
                     help='Path to the CG structure of the protein')
 parser.add_argument('--move_protein', 
-                    type=float, 
+                    type=bool, 
                     required= False, 
                     default=False,  
                     help='Activates the motion of the protein')


### PR DESCRIPTION
Currently the argument is parsed as a float and raises an error if set `True` when given as argument. I understand that `--move_protein 1` would do the trick, but wouldn't it be better if the the type is bool, considering that the default is `False`?