### PR TITLE
fix output for trajectory files for globular proteins for CI testing

### DIFF
--- a/samples/Beyer2024/globular_protein.py
+++ b/samples/Beyer2024/globular_protein.py
@@ -132,8 +132,12 @@ if args.ideal:
     WCA=False
     Electrostatics=False
 
+data_path = args.output
+if data_path is None:
+    data_path=pmb.get_resource(path="samples/Beyer2024/")+"/time_series/globular_protein"
+
 # The trajectories of the simulations will be stored using espresso built-up functions in separed files in the folder 'frames'
-Path("./frames").mkdir(parents=True, 
+Path(f"{data_path}/frames").mkdir(parents=True, 
                        exist_ok=True)
 
 espresso_system = espressomd.System(box_l=[Box_L.to('reduced_length').magnitude] * 3)
@@ -265,7 +269,7 @@ if verbose:
 
 #Save the initial state 
 n_frame = 0
-with open('frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
+with open(f'{data_path}/frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
     vtf.writevsf(espresso_system, coordinates)
     vtf.writevcf(espresso_system, coordinates)
 # Setup the potential energy
@@ -337,7 +341,7 @@ for step in tqdm(range(N_samples),disable=not verbose):
 
     if step % stride_traj == 0 :
         n_frame +=1
-        with open('frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
+        with open(f'{data_path}/frames/trajectory'+str(n_frame)+'.vtf', mode='w+t') as coordinates:
             vtf.writevsf(espresso_system, coordinates)
             vtf.writevcf(espresso_system, coordinates)
 
@@ -349,9 +353,7 @@ for step in tqdm(range(N_samples),disable=not verbose):
         charge_amino = np.mean(charge_residues_per_type[label])
         time_series[label].append(charge_amino)
 
-data_path = args.output
-if data_path is None:
-    data_path=pmb.get_resource(path="samples/Beyer2024/")+"/time_series/globular_protein"
+
 
 Path(data_path).mkdir(parents=True, 
                        exist_ok=True)

--- a/testsuite/globular_protein_functional_tests.py
+++ b/testsuite/globular_protein_functional_tests.py
@@ -26,8 +26,7 @@ import numpy as np
 import pandas as pd
 import unittest as ut
 import glob 
-import re 
-        
+       
 
 root = pathlib.Path(__file__).parent.parent.resolve()
 data_root = root / "testsuite" / "globular_protein_tests_data"

--- a/testsuite/globular_protein_functional_tests.py
+++ b/testsuite/globular_protein_functional_tests.py
@@ -32,7 +32,6 @@ import re
 root = pathlib.Path(__file__).parent.parent.resolve()
 data_root = root / "testsuite" / "globular_protein_tests_data"
 script_path = root / "samples" / "Beyer2024" / "globular_protein.py"
-frame_folder = root / "frames"
 test_pH_values = [2, 5, 7]
 tasks = ["1beb", "1f6s"]
 mode = "test"
@@ -67,7 +66,25 @@ def kernel_move (protein_pdb):
                         "--mode", "test", "--output",  time_series_path, "--move_protein", "--no_verbose", "--ideal" ]
         print(subprocess.list2cmdline(run_command))
         subprocess.check_output(run_command)
-    return 
+        frame_folder = f"{time_series_path}/frames"
+        list_files = glob.glob(f"{frame_folder}/*.vtf")
+        coords={"first_frame": [],
+                "last_frame": []}
+        # Read the first and the last trajectory to check that the protein has moved
+        for frame in list_files:
+            num = int(frame[-5])
+            with open(frame) as f:
+                for line in f:
+                    line_clean = line.split()
+                    if line_clean: 
+                        header = line_clean[0]
+                        if header.isnumeric():
+                            coord_part = line_clean[1:]
+                            if int (num) == 0:
+                                coords["first_frame"].append(coord_part)
+                            elif int (num) == (len(list_files)-1):
+                                coords["last_frame"].append(coord_part)
+    return coords
 
 
 
@@ -97,29 +114,11 @@ class Test(ut.TestCase):
 
     def test_globular_protein_enable_motion(self):        
 
-        kernel_move("1beb")
-        
-        list_files = glob.glob(f"{frame_folder}/*.vtf")
-        first_trajectory_coord_list = []
-        last_trajectory_coord_list = []
-
-        for frame in list_files:
-            num = re.findall(r'\d+', frame)
-            with open(frame) as f:
-                for line in f:
-                    line_clean = line.split()
-                    if line_clean: 
-                        header = line_clean[0]
-                        if header.isnumeric():
-                            coord_part = line_clean[1:]
-                            if int (num[0]) == 0:
-                                first_trajectory_coord_list.append(coord_part)
-                            elif int (num[0]) == (len(list_files)-1):
-                                last_trajectory_coord_list.append(coord_part)
-
-        print(first_trajectory_coord_list)
-        print(last_trajectory_coord_list)
-        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, first_trajectory_coord_list, last_trajectory_coord_list)
+        coords=kernel_move("1beb")
+        np.testing.assert_raises(AssertionError, 
+                                 np.testing.assert_array_equal, 
+                                 coords["first_frame"], 
+                                 coords["last_frame"])
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
The biweekly CI testing for the functional tests failed because the functional test for the `--move_protein` feature that we added was not saving the trajectories in a temporary directory findable by the CI system. Here I fixed the issue.