### PR TITLE
Fix read and write from `pmb.df`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `pd.NA` is now enforced as value for empty cells in `pmb.df`, this prevents transformation of variable types from `int` to `float` which was breaking the code when reading `pmb.df` from file (See #103). (#116)
 - The sample script `plot_HH.py` has been replaced for specific examples on how to plot data post-processed with pyMBE: `plot_branched_polyampholyte.py`, `plot_peptide.py`, and `plot_peptide_mixture_grxmc_ideal.py`. (#95)
 - Sample scripts now take the pH as an argparse input instead of looping over several pH values. This enables paralization of the sample scripts and avoids conflicts with the current post-processing pipeline. (#95)
 - Switched from `os.makedirs` to `Path().mkdir()` to prevent ocasional failure of the scripts when running them in paralel. (#91)
@@ -28,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit testing for reaction methods, bonds, object serialization. (#86, #113)
 
 ### Fixed
+- Writing and reading `pmb.df` from file does no longer change the variable type from `int` to `float` when there are empty cells in the column. (#116)
+- Espresso bond objects stored in `pmb.df` now retain the same value for the  `._bond_id` attribute as the original Espresso objects. (#116)
 - Wrong parsing in `pmb.protein_sequence_parser` of input sequences provided as a list of aminoacids using the three letter code. (#101)
 - Wrong setup of the rigid object in `pmb.enable_motion_of_rigid_object`, leading to crashes in `samples/globular_protein.py` when enabling the protein motion. (#101)
 - The argparse argument `--move_protein` of `samples/globular_protein.py` is now a boolean flag instead of taking arbitrary float values. (#101)

--- a/testsuite/bond_tests.py
+++ b/testsuite/bond_tests.py
@@ -54,7 +54,7 @@ class Test(ut.TestCase):
             np.testing.assert_equal(actual=bond_params[key],
                     desired=input_parameters[key].m_as(reduced_units[key]),
                     verbose=True)
-
+        
     def test_bond_harmonic(self):
         pmb.define_particle(name='A', z=0, sigma=0.4*pmb.units.nm, epsilon=1*pmb.units('reduced_energy'))
 
@@ -82,14 +82,19 @@ class Test(ut.TestCase):
                               bond_type=bond_type)
 
         # check bond deserialization
+        bond_params =  bond_object._ctor_params
+        bond_params["bond_id"] = bond_object._bond_id
         deserialized = pmb.convert_str_to_bond_object(
-            f'{bond_object.__class__.__name__}({json.dumps(bond_object.get_params())})')
+            f'{bond_object.__class__.__name__}({json.dumps(bond_params)})')
         self.check_bond_setup(bond_object=deserialized,
                               input_parameters=bond,
                               bond_type=bond_type)
 
     def test_bond_fene(self):
-        pmb.define_particle(name='A', z=0, sigma=0.4*pmb.units.nm, epsilon=1*pmb.units('reduced_energy'))
+        pmb.define_particle(name='A',
+                             z=0, 
+                             sigma=0.4*pmb.units.nm, 
+                             epsilon=1*pmb.units('reduced_energy'))
 
         bond_type = 'FENE'
         bond = {'r_0'    : 0.4 * pmb.units.nm,
@@ -116,8 +121,10 @@ class Test(ut.TestCase):
                               bond_type=bond_type)
 
         # check bond deserialization
+        bond_params =  bond_object._ctor_params
+        bond_params["bond_id"] = bond_object._bond_id
         deserialized = pmb.convert_str_to_bond_object(
-            f'{bond_object.__class__.__name__}({json.dumps(bond_object.get_params())})')
+            f'{bond_object.__class__.__name__}({json.dumps(bond_params)})')
         self.check_bond_setup(bond_object=deserialized,
                               input_parameters=bond,
                               bond_type=bond_type)

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 pyMBE-dev team
+# Copyright (C) 2024-2025 pyMBE-dev team
 #
 # This file is part of pyMBE.
 #
@@ -452,7 +452,7 @@ else:
 
 print("*** Unit test passed ***")
 
-print("*** Unit test: check that create_molecule() does not create any molcule for number_of_molecules <= 0  ***")
+print("*** Unit test: check that create_molecule() does not create any molecule for number_of_molecules <= 0  ***")
 
 starting_number_of_particles=len(espresso_system.part.all())
 pmb.create_molecule(name="M2",

--- a/testsuite/globular_protein_unit_tests.py
+++ b/testsuite/globular_protein_unit_tests.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 pyMBE-dev team
+# Copyright (C) 2024-2025 pyMBE-dev team
 #
 # This file is part of pyMBE.
 #
@@ -186,8 +186,8 @@ for id in particle_id_list:
 
     residue_id = pmb.df.loc[pmb.df['particle_id']==id].residue_id.values[0]
     residue_name = pmb.df.loc[pmb.df['particle_id']==id].name.values[0]
-
-    initial_pos = topology_dict[residue_name+residue_id]['initial_pos']
+    
+    initial_pos = topology_dict[f"{residue_name}{residue_id}"]['initial_pos']
     index = pmb.df.loc[pmb.df['particle_id']==id].index
 
     for axis in axis_list:

--- a/testsuite/parameter_test.py
+++ b/testsuite/parameter_test.py
@@ -20,7 +20,10 @@ import pathlib
 import pyMBE
 import pandas as pd
 import numpy as np
-pd.set_option('future.no_silent_downcasting', True)
+version = pd.__version__.split(".")
+# This feature was introduced in Pandasv2.2.0
+if int(version[0]) >= 2 and int(version[1]) >= 2:
+    pd.set_option('future.no_silent_downcasting', True)
 
 pmb = pyMBE.pymbe_library(seed=42)
 

--- a/testsuite/parameter_test.py
+++ b/testsuite/parameter_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 pyMBE-dev team
+# Copyright (C) 2024-2025 pyMBE-dev team
 #
 # This file is part of pyMBE.
 #
@@ -20,6 +20,7 @@ import pathlib
 import pyMBE
 import pandas as pd
 import numpy as np
+pd.set_option('future.no_silent_downcasting', True)
 
 pmb = pyMBE.pymbe_library(seed=42)
 
@@ -45,18 +46,19 @@ path_to_pka=pmb.get_resource("parameters/pka_sets/Hass2015.json")
 # First order of loading parameters
 pmb.setup_df() # clear the pmb_df
 pmb.load_interaction_parameters (filename=path_to_interactions) 
-pmb.load_pka_set (filename=path_to_pka)
+pmb.load_pka_set(filename=path_to_pka)
 df_1 = pmb.df.copy()
 df_1 = df_1.sort_values(by="name").reset_index(drop=True)
 # Drop espresso types (they depend on the order of loading)
 df_1 = df_1.drop(labels=('state_one', 'es_type'), axis=1).drop(labels=('state_two', 'es_type'), axis=1)
 # Drop bond_object  (assert_frame_equal does not process it well)
 df_1 = df_1.sort_index(axis=1).drop(labels="bond_object", axis=1)
-
 # Second order of loading parameters
 pmb.setup_df() # clear the pmb_df
 pmb.load_pka_set (filename=path_to_pka)
-pmb.load_interaction_parameters (filename=path_to_interactions) 
+#print(pmb.df["acidity"])
+pmb.load_interaction_parameters(filename=path_to_interactions) 
+#print(pmb.df["acidity"])
 df_2 = pmb.df.copy()
 df_2 = df_2.sort_values(by="name").reset_index(drop=True)
 # Drop espresso types (they depend on the order of loading)
@@ -64,6 +66,8 @@ df_2 = df_2.drop(labels=('state_one', 'es_type'), axis=1).drop(labels=('state_tw
 # Drop bond_object  (assert_frame_equal does not process it well)
 df_2 = df_2.sort_index(axis=1).drop(labels="bond_object", axis=1)
 
+df_1 = df_1.replace({pd.NA: np.nan})
+df_2 = df_2.replace({pd.NA: np.nan})
 pd.testing.assert_frame_equal(df_1,df_2)
 
 print("*** Test passed ***")
@@ -73,8 +77,8 @@ pmb.setup_df() # clear the pmb_df
 path_to_interactions=pmb.get_resource("testsuite/test_parameters/test_FENE.json")
 pmb.load_interaction_parameters (filename=path_to_interactions) 
 
-expected_parameters = {'r_0'    : 0.4*pmb.units.nm,
-                        'k'      : 400 * pmb.units('reduced_energy / reduced_length**2'),
+expected_parameters = {'r_0' : 0.4*pmb.units.nm,
+                        'k'  : 400 * pmb.units('reduced_energy / reduced_length**2'),
                         'd_r_max': 0.8 * pmb.units.nm}
 reduced_units = {'r_0'    : 'reduced_length',
                      'k'      : 'reduced_energy / reduced_length**2',

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -20,7 +20,11 @@ import tempfile
 import espressomd
 import pandas as pd
 import numpy as np
-pd.set_option('future.no_silent_downcasting', True)
+
+version = pd.__version__.split(".")
+# This feature was introduced in Pandasv2.2.0
+if int(version[0]) >= 2 and int(version[1]) >= 2:
+    pd.set_option('future.no_silent_downcasting', True)
 
 # Create an instance of pyMBE library
 import pyMBE

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 pyMBE-dev team
+# Copyright (C) 2024-2025 pyMBE-dev team
 #
 # This file is part of pyMBE.
 #
@@ -19,6 +19,8 @@
 import tempfile
 import espressomd
 import pandas as pd
+import numpy as np
+pd.set_option('future.no_silent_downcasting', True)
 
 # Create an instance of pyMBE library
 import pyMBE
@@ -90,6 +92,17 @@ harmonic_bond = {'r_0'    : generic_bond_length,
 
 
 pmb.define_default_bond(bond_type = bond_type, bond_parameters = harmonic_bond)
+pmb.define_bond(bond_type = bond_type, 
+                bond_parameters = harmonic_bond,
+                particle_pairs=[["A","A"],["B","B"]])
+bond_type = 'FENE'
+FENE_bond = {'r_0'    : 0.4 * pmb.units.nm,
+                'k'      : 400 * pmb.units('reduced_energy / reduced_length**2'),
+                'd_r_max': 0.8 * pmb.units.nm}
+
+pmb.define_bond(bond_type = bond_type, 
+                bond_parameters = FENE_bond,
+                particle_pairs=[["A","B"]])
 
 # Solution parameters
 cation_name = 'Na'
@@ -104,6 +117,7 @@ molecule_concentration = 5.56e-4 *pmb.units.mol/pmb.units.L
 volume = n_molecules/(pmb.N_A*molecule_concentration)
 L = volume ** (1./3.) # Side of the simulation box
 espresso_system=espressomd.System (box_l = [L.to('reduced_length').magnitude]*3)
+pmb.add_bonds_to_espresso(espresso_system = espresso_system)
 
 # Setup potential energy
 
@@ -120,12 +134,18 @@ with tempfile.TemporaryDirectory() as tmp_directory:
     # Read the same pyMBE df from a csv a load it in pyMBE
     read_df = pmb.read_pmb_df(filename = df_filename)
 
+
 # Preprocess data for the Unit Test
 # The espresso bond object must be converted to a dict in order to compare them using assert_frame_equal
-stored_df['bond_object']  = stored_df['bond_object'].apply(lambda x: (x.name(), x.get_params()) if pd.notnull(x) else x)
-read_df['bond_object']  = read_df['bond_object'].apply(lambda x: (x.name(), x.get_params()) if pd.notnull(x) else x)
-
+stored_df['bond_object']  = stored_df['bond_object'].apply(lambda x: (x.name(), x.get_params(), x._bond_id) if pd.notnull(x) else x)
+read_df['bond_object']  = read_df['bond_object'].apply(lambda x: (x.name(), x.get_params(), x._bond_id) if pd.notnull(x) else x)
 print("*** Unit test: check that the dataframe stored by pyMBE to file is the same as the one read from the file (same values and variable types) ***")
 
-pd.testing.assert_frame_equal (stored_df, read_df, check_exact= True)
+# One needs to replace the pd.NA by np.nan otherwise the comparison between pint objects fails
+stored_df = stored_df.replace({pd.NA: np.nan})
+read_df = read_df.replace({pd.NA: np.nan})
+
+pd.testing.assert_frame_equal(stored_df, 
+                                read_df,
+                                rtol=1e-5)
 print("*** Unit test passed***")


### PR DESCRIPTION
Solves #102 and  #114 finally.

### Changed
- `pd.NA` is now enforced as value for empty cells in `pmb.df`, this prevents transformation of variable types from `int` to `float` which was breaking the code when reading `pmb.df` from file (See #103). (#116)

### Fixed
- Writing and reading `pmb.df` from file does no longer change the variable type from `int` to `float` when there are empty cells in the column. (#116)
- Espresso bond objects stored in `pmb.df` now retain the same value for the  `._bond_id` attribute as the original Espresso objects. (#116)

I had to do quite a bit of refactoring to make the code work with `pd.NA` because it behaves differently than `np.nan`, but I checked that all functional tests still run. To solve the bookkeeping of  `._bond_id` I had to hack a bit the espresso bond object because otherwise it was hard to backtrack it. 

@paobtorres @1234somesh this PR solves the issues you raised!