### PR TITLE
Add functionality in `handy_functions.setup_electrostatic_interactions` to include parameters for electrostatics solvers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ The following people have contributed to pyMBE (Github username, Name, current a
 - 1234somesh, Somesh Kurahatti (University of Stuttgart, Germany)
 - amartise, Albert Martinez-Serra (Royal College of Surgeons, Ireland) 
 - mariusaarsten, Marius Aarsten (Norwegian University of Science and Tecnology, Norway)
+- TommyTraan, Duy Tommy Tran (Norwegian University of Science and Tecnology, Norway)
 - Zitzeronion, Stefan Zitz (Research Center Pharmaceutical Engineering, Austria)
 
 ## Early testers of the library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched to CTest for testing, allowing to run the tests on paralel (#87)
 
 ### Added
+- Optional argument `params` in `lib.handy_functions.setup_electrostatic_interactions` enabling the user to easilly tune parameters for the electrostatic solvers. (#121)
 - CI testing for functions in `lib.handy_functions`. (#118)
 - sanity tests for `lib.handy_functions`. (#118)
 - Use of `logging`  in `lib.handy_functions` to handle output and error logs. (#118)

--- a/lib/handy_functions.py
+++ b/lib/handy_functions.py
@@ -24,13 +24,15 @@ def setup_electrostatic_interactions(units, espresso_system, kT, c_salt=None, so
 
     Args:
         units(`pint.UnitRegistry`): Unit registry for handling physical units.
-        espresso_system (`espressomd.system.System`): system object of espressomd library.
+        espresso_system(`espressomd.system.System`): system object of espressomd library.
         kT(`pint.Quantity`): Thermal energy.
         c_salt(`pint.Quantity`): Added salt concentration. If provided, the program outputs the debye screening length. It is a mandatory parameter for the Debye-Hückel method.
         solvent_permittivity (`float`): Solvent relative permittivity. Defaults to 78.5, correspoding to its value in water at 298.15 K.
-        method (`str`): Method for computing electrostatic interactions. Defaults to "p3m". 
-        tune_p3m (`bool`): If True, tunes P3M parameters for efficiency. Defaults to True. 
-        accuracy (`float`): Desired accuracy for electrostatics. Defaults to 1e-3.
+        method(`str`): Method for computing electrostatic interactions. Defaults to "p3m". 
+        tune_p3m(`bool`): If True, tunes P3M parameters for efficiency. Defaults to True. 
+        accuracy(`float`): Desired accuracy for electrostatics. Defaults to 1e-3.
+        params(`dict`): Additional parameters for the electrostatic method. For P3M, it can include 'mesh', 'alpha', 'cao' and `r_cut`. For Debye-Hückel, it can include 'r_cut'.
+        verbose(`bool`): If True, enables verbose output for P3M tuning. Defaults to False.
 
     Note:
         `c_salt` is a mandatory argument for setting up the Debye-Hückel electrostatic potential.

--- a/testsuite/test_handy_functions.py
+++ b/testsuite/test_handy_functions.py
@@ -205,6 +205,21 @@ class Test(ut.TestCase):
                          second=coloumb_params["is_tuned"],
                          msg="lib.handy_functions.setup_electrostatic_interactions does not tune the P3M method")
         espresso_system.actors.remove(coloumb)
+        ## Test the setup the P3M method without tuning it with some input parameters
+        electrostatics_inputs["tune_p3m"] = False
+        electrostatics_inputs["params"] = {"mesh": [8, 8, 8], 
+                                           "cao": 5, 
+                                           "alpha": 1.1265e+01,
+                                           "r_cut": 1}
+        hf.setup_electrostatic_interactions(**electrostatics_inputs)
+        coloumb = espresso_system.actors.active_actors.copy()[0]
+        coloumb_params = coloumb.get_params()
+        for param in electrostatics_inputs["params"]:
+            self.assertEqual(first=electrostatics_inputs["params"][param],
+                             second=coloumb_params[param],
+                             msg="lib.handy_functions.setup_electrostatic_interactions sets up the wrong P3M parameters")
+        espresso_system.actors.remove(coloumb)
+        electrostatics_inputs["params"] = None
         # Test the Debye–Hückel setup
         electrostatics_inputs["method"] = "dh"
         electrostatics_inputs["c_salt"] = pmb.units.Quantity(1, "mol/L")
@@ -222,7 +237,7 @@ class Test(ut.TestCase):
                                 second=(1./kappa).m_as('1/ reduced_length'),
                                 msg="lib.handy_functions.setup_electrostatic_interactions sets up the wrong Debye screening length for the DH method")
         self.assertAlmostEqual(first=dh_params["r_cut"],
-                                second=2.5*kappa.m_as('reduced_length'),
+                                second=3*kappa.m_as('reduced_length'),
                                 msg="lib.handy_functions.setup_electrostatic_interactions sets up the wrong cut-off for the DH method")
         espresso_system.actors.remove(dh)
         electrostatics_inputs["c_salt"] = pmb.units.Quantity(1, "mol/L")*pmb.N_A
@@ -233,7 +248,16 @@ class Test(ut.TestCase):
                                 second=(1./kappa).m_as('1/ reduced_length'),
                                 msg="lib.handy_functions.setup_electrostatic_interactions sets up the wrong Debye screening length for the DH method")
         self.assertAlmostEqual(first=dh_params["r_cut"],
-                                second=2.5*kappa.m_as('reduced_length'),
+                                second=3*kappa.m_as('reduced_length'),
+                                msg="lib.handy_functions.setup_electrostatic_interactions sets up the wrong cut-off for the DH method")
+        espresso_system.actors.remove(dh)
+        # Test a non-default cut-off
+        electrostatics_inputs["params"] = {"r_cut": 3}
+        hf.setup_electrostatic_interactions(**electrostatics_inputs)
+        dh = espresso_system.actors.active_actors.copy()[0]
+        dh_params = dh.get_params()
+        self.assertAlmostEqual(first=dh_params["r_cut"],
+                                second=electrostatics_inputs["params"]["r_cut"],
                                 msg="lib.handy_functions.setup_electrostatic_interactions sets up the wrong cut-off for the DH method")
         print("*** Unit test passed ***")
 if __name__ == "__main__":


### PR DESCRIPTION
### Added
- Optional argument `params` in `lib.handy_functions.setup_electrostatic_interactions` enabling the user to easilly tune parameters for the electrostatic solvers. 