### PR TITLE
cov: get_lj_parameters and read_pmf_df

### DIFF
--- a/pyMBE.py
+++ b/pyMBE.py
@@ -3510,11 +3510,7 @@ class pymbe_library():
 
         """
         from itertools import combinations_with_replacement
-        implemented_combining_rules = ['Lorentz-Berthelot']
         compulsory_parameters_in_df = ['sigma','epsilon']
-        # Sanity check
-        if combining_rule not in implemented_combining_rules:
-            raise ValueError('In the current version of pyMBE, the only combinatorial rules implemented are ', implemented_combining_rules)
         shift=0
         if shift_potential:
             shift="auto"

--- a/testsuite/lj_tests.py
+++ b/testsuite/lj_tests.py
@@ -207,4 +207,12 @@ for label in lj_labels:
         raise Exception("*** Unit Test failed ***")
 
 print("*** Unit test passed ***")
+
+print("*** Unit test: test that get_lj_parameters() rasie the ValueError when the combination rule is not Loretz-Berthelot ***")
+
+input_params = {"particle_name1":"A", "particle_name2":"B", "combining_rule":"Geometric"}
+np.testing.assert_raises(ValueError, pmb.get_lj_parameters, **input_params)
+
+print("*** All unit tests passed ***")
+
 print("*** All unit tests passed ***")

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -136,6 +136,10 @@ with tempfile.TemporaryDirectory() as tmp_directory:
     pmb.write_pmb_df (filename = df_filename)
     # Read the same pyMBE df from a csv a load it in pyMBE
     read_df = pmb.read_pmb_df(filename = df_filename)
+    # Write the pyMBE DF to a txt file
+    df_filename_test = f"{tmp_directory}/df-example_molecule.txt"
+    pmb.write_pmb_df (filename = df_filename_test)
+    np.testing.assert_raises(ValueError, pmb.read_pmb_df, df_filename_test)
 
 stored_df['node_map'] = stored_df['node_map'].astype(object)
 stored_df['chain_map'] = stored_df['chain_map'].astype(object)


### PR DESCRIPTION
## Adds
* Unit test for `pymbe_library.get_lj_parameters`,  ValueError exception for unknown combining rule.
* Unit test for `pymbe_library.read_pmb_df`  ValueError exception for unsupported file format.