### PR TITLE
bugfix: remove series of LD integration with increasing gamma values in relax_espresso_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched to CTest for testing, allowing to run the tests on paralel (#87)
 
 ### Added
+- Support for conda and miniconda virtual environments. (#134)
 - Private methods for sanity checks, used in various methods to ensure that the inputs are pyMBE objects of the expected type. (#126)
 - New benchmark for hydrogels, including scripts to reproduce the data `samples/Landsgesell2022/run_simulations.py` and `samples/Landsgesell2022/plot_pH_vs_alpha.py` and `samples/Landsgesell2022/plot_P_vs_V.py` (#103)
 - New sample scripts for hydrogels `samples/build_hydrogel.py` and  `samples/weak_polyacid_hydrogel_grxmc.py` (#103)

--- a/testsuite/test_handy_functions.py
+++ b/testsuite/test_handy_functions.py
@@ -55,7 +55,6 @@ relax_inputs={"espresso_system":espresso_system,
               "gamma":0.01,
               "Nsteps_steepest_descent":5000, 
               "max_displacement":0.1, 
-              "Nmax_iter_relax":100, 
               "Nsteps_iter_relax":500,
               "seed": seed}
 
@@ -153,8 +152,6 @@ class Test(ut.TestCase):
         broken_inputs["max_displacement"] = -1
         self.assertRaises(ValueError, hf.relax_espresso_system, **broken_inputs)
         broken_inputs  = relax_inputs.copy()
-        broken_inputs["Nmax_iter_relax"] = -1
-        self.assertRaises(ValueError, hf.relax_espresso_system, **broken_inputs)
 
     def test_relax_espresso_system(self):
         """Test :func:`lib.handy_functions.relax_espresso_system`"""

--- a/testsuite/test_handy_functions.py
+++ b/testsuite/test_handy_functions.py
@@ -155,18 +155,36 @@ class Test(ut.TestCase):
 
     def test_relax_espresso_system(self):
         """Test :func:`lib.handy_functions.relax_espresso_system`"""
-        espresso_system.part.add(pos=[1,1,1])
-        espresso_system.part.add(pos=[1.15,1.15,1.15])
-        espresso_system.part.add(pos=[1.5,1.5,1.5])
-        espresso_system.part.add(pos=[2,2,2])
-        espresso_system.part.add(pos=[2.15,2.15,2.15])
-        espresso_system.part.add(pos=[1,1,1.5])
+        positions = [[1,1,1], 
+                     [1.15,1.15,1.15], 
+                     [1.5,1.5,1.5],
+                     [2,2,2],
+                     [2.15,2.15,2.15],
+                     [1,1,1.5]]
+        for pos in positions:
+            espresso_system.part.add(pos=pos)
         espresso_system.non_bonded_inter[0,0].lennard_jones.set_params(
             epsilon = 1, sigma = 1, cutoff = 2**(1./6.), shift = "auto")
         min_dist = hf.relax_espresso_system(**relax_inputs)
         self.assertGreater(a=min_dist,
                            b=0.9,
                            msg="lib.handy_functions.relax_espresso_system is unable to relax a simple lj system")
+        espresso_system.part.clear()
+        # Test that the LD run is actually performed
+        for pos in positions:
+            espresso_system.part.add(pos=pos)
+        test_inputs  = relax_inputs.copy()
+        test_inputs["Nsteps_steepest_descent"] = 1
+        test_inputs["max_displacement"] = 0.1
+        hf.relax_espresso_system(**relax_inputs)
+        new_positions = espresso_system.part.all().pos
+        distances = np.linalg.norm(np.array(positions) - new_positions, 
+                                   axis=1)
+        # Check that the positions have changed
+        self.assertTrue(np.all(distances > 0.1),
+                        msg="lib.handy_functions.relax_espresso_system does not change the positions of the particles during relaxation")
+
+
 
     def test_exceptions_electrostatics(self):
         """Test exceptions in :func:`lib.handy_functions.setup_electrostatic_interactions`"""

--- a/testsuite/test_handy_functions.py
+++ b/testsuite/test_handy_functions.py
@@ -175,7 +175,7 @@ class Test(ut.TestCase):
             espresso_system.part.add(pos=pos)
         test_inputs  = relax_inputs.copy()
         test_inputs["Nsteps_steepest_descent"] = 1
-        test_inputs["max_displacement"] = 0.1
+        test_inputs["max_displacement"] = 0
         hf.relax_espresso_system(**relax_inputs)
         new_positions = espresso_system.part.all().pos
         distances = np.linalg.norm(np.array(positions) - new_positions, 


### PR DESCRIPTION
Simplifies the LD relaxation done in `handy_tools.relax_espresso_system` and improves its documentation to make users aware that the procedure and parameters proposed for relaxation are by no means general.

I ran all tests (including the functional ones) and everything seems to be fine. I also tested the sample scripts using various seeds for the random generator and I did not experience any random crash. Therefore, the relaxation seems to be enough for our current sample scripts. However, we shall re-consider if we really want to keep supporting this function since it is going to be increasingly difficult to ensure its suitability for new systems.