### PR TITLE
add complete coverage and deprecated destroy pmb object

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
-pyMBE is maintained and developed by several authors from different institutions in collaboration.
+pyMBE is maintained and developed in collaboration by several authors from different institutions.
 The following people have contributed to pyMBE (Github username, Name, current affiliation):
 
 ## Admins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unsupported ESPResSo features now raise a `NotImplementedError` instead of a `ValueError`. (#113)
 
 ### Removed
+- `pmb.create_pmb_object` has been deprecated in favor of case-specific creation methods. (#137)
 - `pmb.get_resource()` is no longer needed because pyMBE has been restructured as a package and therefore all of its resources are internally accessible. (#135)
 - `lib/create_cg_from_pdb.py` because it was not covered by CI testing and it was imposing a too restrictive coarse-graning of globular proteins to be used for the general public. Future development plans include substituting this functunality for a more general parser. (#135)
 - `tutorials/solution_tutorial.ipynb` to avoid code repetition. Instead, the exercise in `pyMBE_tutorial.ipynb` has been adapted to match one of the example in `samples/branched_polyampholyte.py`. (#130)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched to CTest for testing, allowing to run the tests on paralel (#87)
 
 ### Added
+- Case-specific methods to delete particles, residues in molecules in pyMBE: `delete_particle_in_system`, `delete_residue_in_system`, `delete_molecule_in_system`. (#137)
 - Support for conda and miniconda virtual environments. (#134)
 - Private methods for sanity checks, used in various methods to ensure that the inputs are pyMBE objects of the expected type. (#126)
 - New benchmark for hydrogels, including scripts to reproduce the data `samples/Landsgesell2022/run_simulations.py` and `samples/Landsgesell2022/plot_pH_vs_alpha.py` and `samples/Landsgesell2022/plot_P_vs_V.py` (#103)
@@ -60,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unsupported ESPResSo features now raise a `NotImplementedError` instead of a `ValueError`. (#113)
 
 ### Removed
+- `pmb.destroy_pmb_object` has been deprecated in favor of case-specific deletion methods. (#137)
 - `pmb.create_pmb_object` has been deprecated in favor of case-specific creation methods. (#137)
 - `pmb.get_resource()` is no longer needed because pyMBE has been restructured as a package and therefore all of its resources are internally accessible. (#135)
 - `lib/create_cg_from_pdb.py` because it was not covered by CI testing and it was imposing a too restrictive coarse-graning of globular proteins to be used for the general public. Future development plans include substituting this functunality for a more general parser. (#135)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched to CTest for testing, allowing to run the tests on paralel (#87)
 
 ### Added
-- Case-specific methods to delete particles, residues in molecules in pyMBE: `delete_particle_in_system`, `delete_residue_in_system`, `delete_molecule_in_system`. (#137)
+- Case-specific methods to delete particles, residues and molecules in pyMBE: `delete_particle_in_system`, `delete_residue_in_system`, `delete_molecule_in_system`. (#137)
 - Support for conda and miniconda virtual environments. (#134)
 - Private methods for sanity checks, used in various methods to ensure that the inputs are pyMBE objects of the expected type. (#126)
 - New benchmark for hydrogels, including scripts to reproduce the data `samples/Landsgesell2022/run_simulations.py` and `samples/Landsgesell2022/plot_pH_vs_alpha.py` and `samples/Landsgesell2022/plot_P_vs_V.py` (#103)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Please contribute to pyMBE!
 
 ## Bug reporting
-If you discover any strange feature or unexpected behaviour of the module, please report it by opening an issue in this GitHub repository or contacting Dr. Pablo M. Blanco (pablb@ntnu.no) or any other member of the pyMBE development team.
+If you discover any strange feature or unexpected behaviour of the module, please report it by opening an issue in this GitHub repository or contacting Dr. Pablo M. Blanco ([@pm-blanco](https://github.com/pm-blanco)) or any other member of the pyMBE development team.
 Once a ticket is open in GitHub, we will work to fix the issue as soon as possible.
 
 ## New contributors
 New developers are welcome to contribute to extend the functionalities of the pyMBE module. 
 To contribute to the pyMBE module, first one needs to be added as a member of this GitHub repository.
-If you want to contribute to the development of the pyMBE module, please contact Dr. Pablo M. Blanco (pablb@ntnu.no).
+If you want to contribute to the development of the pyMBE module, please contact Dr. Pablo M. Blanco ([@pm-blanco](https://github.com/pm-blanco)).
 
 ## Authorship system
 To warrant a co-author status, one should contribute in one of the following way:
-- New methods and modules that extend the functionalies of the module.
+- New methods and modules that extend the functionalities of the module.
 - Bugfixes and code enhancements that improve the quality of the module.
 - Development of tutorials and other documentation of the module.
 - Scripts for samples on how to use pyMBE, for testing of the library or for handy tools to extend the features fo the library.
@@ -46,4 +46,4 @@ We follow semantic versioning and keep a changelog.
 
 ## Community standards
 We aim to keep the pyMBE community an open and friendly space for researchers to collaborate in developing tools for building coarse-grained models of polyelectrolytes and biomolecules. 
-We adhere to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md) v2.1 to provide guidelines on the expected behaviour of the members of our community, which we hope it contributes to a healthy and a positive enviroment for our developers and users. 
+We adhere to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md) v2.1 to provide guidelines on the expected behavior of the members of our community, which we hope it contributes to a healthy and a positive environment for our developers and users. 

--- a/pyMBE/pyMBE.py
+++ b/pyMBE/pyMBE.py
@@ -1927,7 +1927,7 @@ class pymbe_library():
         The ids of the molecule, particle and residues deleted are also cleaned from `pmb.df`
 
         Args:
-            molecule_id(`str`): id of the molecule to be deleted. 
+            molecule_id(`int`): id of the molecule to be deleted. 
             espresso_system(`espressomd.system.System`): Instance of a system class from espressomd library.
 
         """
@@ -1961,7 +1961,7 @@ class pymbe_library():
         The particle ids of the particle and residues deleted are also cleaned from `pmb.df`
 
         Args:
-            molecule_id(`str`): id of the molecule to be deleted. 
+            particle_id(`int`): id of the molecule to be deleted. 
             espresso_system(`espressomd.system.System`): Instance of a system class from espressomd library.
 
         """
@@ -1979,7 +1979,7 @@ class pymbe_library():
         The ids of the residue and particles deleted are also cleaned from `pmb.df`
 
         Args:
-            residue_id(`str`): id of the residue to be deleted. 
+            residue_id(`int`): id of the residue to be deleted. 
             espresso_system(`espressomd.system.System`): Instance of a system class from espressomd library.
         """
         # Sanity check if there is a residue with the input residue id

--- a/pyMBE/pyMBE.py
+++ b/pyMBE/pyMBE.py
@@ -1254,44 +1254,6 @@ class pymbe_library():
             self.add_value_to_df(key=('particle_id',''),index=df_index,new_value=bead_id)                  
         return created_pid_list
 
-    def create_pmb_object(self, name, number_of_objects, espresso_system, position=None, use_default_bond=False, backbone_vector=None):
-        """
-        Creates all `particle`s associated to `pmb object` into  `espresso` a number of times equal to `number_of_objects`.
-        
-        Args:
-            name(`str`): Unique label of the `pmb object` to be created. 
-            number_of_objects(`int`): Number of `pmb object`s to be created.
-            espresso_system(`espressomd.system.System`): Instance of an espresso system object from espressomd library.
-            position(`list`): Coordinates where the particles should be created.
-            use_default_bond(`bool`,optional): Controls if a `default` bond is used to bond particles with undefined bonds in `pmb.df`. Defaults to `False`.
-            backbone_vector(`list` of `float`): Backbone vector of the molecule, random by default. Central beads of the residues in the `residue_list` are placed along this vector. 
-
-        Note:
-            - If no `position` is given, particles will be created in random positions. For bonded particles, they will be created at a distance equal to the bond length. 
-        """
-        pmb_type = self._check_supported_molecule(molecule_name=name,
-                                        valid_pmb_types=["molecule","particle","residue","peptide"])
-        
-        if pmb_type == 'particle':
-            self.create_particle(name=name, 
-                                number_of_particles=number_of_objects, 
-                                espresso_system=espresso_system, 
-                                position=position)
-        elif pmb_type == 'residue':
-            self.create_residue(name=name,  
-                                espresso_system=espresso_system, 
-                                central_bead_position=position,
-                                use_default_bond=use_default_bond,
-                                backbone_vector=backbone_vector)
-        elif pmb_type in ['molecule','peptide']:
-            self.create_molecule(name=name, 
-                                number_of_molecules=number_of_objects, 
-                                espresso_system=espresso_system, 
-                                use_default_bond=use_default_bond, 
-                                list_of_first_residue_positions=position,
-                                backbone_vector=backbone_vector)
-        return
-
     def create_protein(self, name, number_of_proteins, espresso_system, topology_dict):
         """
         Creates `number_of_proteins` molecules of type `name` into `espresso_system` at the coordinates in `positions`
@@ -1655,10 +1617,7 @@ class pymbe_library():
         self._check_if_multiple_pmb_types_for_name(name='default',
                                                    pmb_type_to_be_defined='bond')
          
-        if len(self.df.index) != 0:
-            index = max(self.df.index)+1
-        else:
-            index = 0
+        index = max(self.df.index, default=-1) + 1
         self.df.at [index,'name']        = 'default'
         self.df.at [index,'bond_object'] = bond_object
         self.df.at [index,'l0']          = l0
@@ -2164,7 +2123,6 @@ class pymbe_library():
                 else: 
                     column_name_value = self.df.loc[idx[index[0]], idx[(column_name,'')]]
                     return column_name_value
-        return None
 
     def format_node(self, node_list):
         return "[" + " ".join(map(str, node_list)) + "]"

--- a/pyMBE/pyMBE.py
+++ b/pyMBE/pyMBE.py
@@ -148,6 +148,24 @@ class pymbe_library():
             if hard_check:
                 raise ValueError(f"The name {name} has been defined in the pyMBE DataFrame with a pmb_type = {pmb_type}. This function only supports pyMBE objects with pmb_type = {expected_pmb_type}")
             return False
+        
+    def _clean_ids_in_df_row(self, row):
+        """
+        Cleans particle, residue and molecules ids in `row`.
+        If there are other repeated entries for the same name, drops the row.
+
+        Args:
+            row(pd.DataFrame): A row from the DataFrame to clean.
+        """
+        columns_to_clean = ['particle_id',
+                            'particle_id2', 
+                            'residue_id', 
+                            'molecule_id']
+        if len(self.df.loc[self.df['name'] == row['name'].values[0]]) > 1:
+            self.df = self.df.drop(row.index).reset_index(drop=True)
+        else:
+            for column_name in columns_to_clean:
+                self.df.loc[row.index, column_name] = pd.NA
 
     def add_bond_in_df(self, particle_id1, particle_id2, use_default_bond=False):
         """
@@ -727,13 +745,8 @@ class pymbe_library():
         if column_name not in valid_column_names:
             raise ValueError(f"{column_name} is not a valid column_name, currently only the following are supported: {valid_column_names}")
         df_by_name = self.df.loc[self.df.name == name]
-        if number_of_copies != 1:           
-            if df_by_name[column_name].isnull().values.any():       
-                df_by_name_repeated = pd.concat ([df_by_name]*(number_of_copies-1), ignore_index=True)
-            else:
-                df_by_name = df_by_name[df_by_name.index == df_by_name.index.min()] 
-                df_by_name_repeated = pd.concat ([df_by_name]*(number_of_copies), ignore_index=True)
-                df_by_name_repeated[column_name] = pd.NA
+        if number_of_copies != 1:                           
+            df_by_name_repeated = pd.concat ([df_by_name]*(number_of_copies-1), ignore_index=True)
             # Concatenate the new particle rows to  `df`
             self.df = pd.concat ([self.df,df_by_name_repeated], ignore_index=True)
         else:
@@ -1908,50 +1921,89 @@ class pymbe_library():
         if entry_name in self.df["name"].values:
             self.df = self.df[self.df["name"] != entry_name].reset_index(drop=True)
 
-    def destroy_pmb_object_in_system(self, name, espresso_system):
+    def delete_molecule_in_system(self, molecule_id, espresso_system):
         """
-        Destroys all particles associated with `name` in `espresso_system` amd removes the destroyed pmb_objects from `pmb.df` 
+        Deletes the molecule with `molecule_id` from the `espresso_system`, including all particles and residues associated with that particles.
+        The ids of the molecule, particle and residues deleted are also cleaned from `pmb.df`
 
         Args:
-            name(`str`): Label of the pmb object to be destroyed. The pmb object must be defined in `pymbe.df`.
+            molecule_id(`str`): id of the molecule to be deleted. 
             espresso_system(`espressomd.system.System`): Instance of a system class from espressomd library.
 
-        Note:
-            - If `name`  is a object_type=`particle`, only the matching particles that are not part of bigger objects (e.g. `residue`, `molecule`) will be destroyed. To destroy particles in such objects, destroy the bigger object instead.
         """
-        pmb_type = self._check_supported_molecule(molecule_name=name,
-                                       valid_pmb_types= ['particle','residue','molecule',"peptide"])
+        # Sanity checks 
+        id_mask = (self.df['molecule_id'] == molecule_id) & (self.df['pmb_type'].isin(["molecule", "peptide"]))
+        molecule_row = self.df.loc[id_mask]
+        if molecule_row.empty:
+            raise ValueError(f"No molecule found with molecule_id={molecule_id} in the DataFrame.")
+        # Clean molecule from pmb.df
+        self._clean_ids_in_df_row(row=molecule_row)
+        # Delete particles and residues in the molecule
+        residue_mask = (self.df['molecule_id'] == molecule_id) & (self.df['pmb_type'] == "residue")
+        residue_rows = self.df.loc[residue_mask]
+        residue_ids = set(residue_rows["residue_id"].values)
+        for residue_id in residue_ids:
+            self.delete_residue_in_system(residue_id=residue_id,
+                                           espresso_system=espresso_system)
         
-        if pmb_type == 'particle':
-            particles_index = self.df.index[(self.df['name'] == name) & (self.df['residue_id'].isna()) 
-                                                  & (self.df['molecule_id'].isna())]
-            particle_ids_list= self.df.loc[(self.df['name'] == name) & (self.df['residue_id'].isna())
-                                                 & (self.df['molecule_id'].isna())].particle_id.tolist()
-            for particle_id in particle_ids_list:
-                espresso_system.part.by_id(particle_id).remove()
-            self.df = self.df.drop(index=particles_index)
-        if pmb_type == 'residue':
-            residues_id = self.df.loc[self.df['name']== name].residue_id.to_list()
-            for residue_id in residues_id:
-                molecule_name = self.df.loc[(self.df['residue_id']==molecule_id) & (self.df['pmb_type']=="residue")].name.values[0]
-                particle_ids_list = self.get_particle_id_map(object_name=molecule_name)["all"]
-                self.df = self.df.drop(self.df[self.df['residue_id'] == residue_id].index)
-                for particle_id in particle_ids_list:
-                    espresso_system.part.by_id(particle_id).remove()
-                    self.df= self.df.drop(self.df[self.df['particle_id']==particle_id].index)    
-        if pmb_type in ['molecule',"peptide"]:
-            molecules_id = self.df.loc[self.df['name']== name].molecule_id.dropna().to_list()
-            for molecule_id in molecules_id:
-                molecule_name = self.df.loc[(self.df['molecule_id']==molecule_id) & (self.df['pmb_type']==pmb_type)].name.values[0]
-                particle_ids_list = self.get_particle_id_map(object_name=molecule_name)["all"]
-                self.df = self.df.drop(self.df[self.df['molecule_id'] == molecule_id].index)
-                for particle_id in particle_ids_list:
-                    espresso_system.part.by_id(particle_id).remove()   
-                    self.df= self.df.drop(self.df[self.df['particle_id']==particle_id].index)             
-        
-        self.df.reset_index(drop=True,inplace=True)
+        # Clean deleted backbone bonds from pmb.df
+        bond_mask = (self.df['molecule_id'] == molecule_id) & (self.df['pmb_type'] == "bond")
+        number_of_bonds = len(self.df.loc[bond_mask])
+        for _ in range(number_of_bonds):
+            bond_mask = (self.df['molecule_id'] == molecule_id) & (self.df['pmb_type'] == "bond")
+            bond_rows = self.df.loc[bond_mask]
+            row=bond_rows.loc[[bond_rows.index[0]]]
+            self._clean_ids_in_df_row(row=row)
 
-        return
+    def delete_particle_in_system(self, particle_id, espresso_system):
+        """
+        Deletes the particle with `particle_id` from the `espresso_system`.
+        The particle ids of the particle and residues deleted are also cleaned from `pmb.df`
+
+        Args:
+            molecule_id(`str`): id of the molecule to be deleted. 
+            espresso_system(`espressomd.system.System`): Instance of a system class from espressomd library.
+
+        """
+        # Sanity check if there is a particle with the input particle id
+        id_mask = (self.df['particle_id'] == particle_id) & (self.df['pmb_type'] == "particle")
+        particle_row = self.df.loc[id_mask]
+        if particle_row.empty:
+            raise ValueError(f"No particle found with particle_id={particle_id} in the DataFrame.")
+        espresso_system.part.by_id(particle_id).remove()
+        self._clean_ids_in_df_row(particle_row)
+
+    def delete_residue_in_system(self, residue_id, espresso_system):
+        """
+        Deletes the residue with `residue_id`, and the particles associated with it from the `espresso_system`.
+        The ids of the residue and particles deleted are also cleaned from `pmb.df`
+
+        Args:
+            residue_id(`str`): id of the residue to be deleted. 
+            espresso_system(`espressomd.system.System`): Instance of a system class from espressomd library.
+        """
+        # Sanity check if there is a residue with the input residue id
+        id_mask = (self.df['residue_id'] == residue_id) & (self.df['pmb_type'] == "residue")
+        residue_row = self.df.loc[id_mask]
+        if residue_row.empty:
+            raise ValueError(f"No residue found with residue_id={residue_id} in the DataFrame.")
+        residue_map=self.get_particle_id_map(object_name=residue_row["name"].values[0])["residue_map"]
+        particle_ids = residue_map[residue_id]
+        # Clean residue from pmb.df
+        self._clean_ids_in_df_row(row=residue_row)
+        # Delete particles in the residue
+        for particle_id in particle_ids:
+            self.delete_particle_in_system(particle_id=particle_id,
+                                           espresso_system=espresso_system)
+        # Clean deleted bonds from pmb.df
+        bond_mask = (self.df['residue_id'] == residue_id) & (self.df['pmb_type'] == "bond")
+        number_of_bonds = len(self.df.loc[bond_mask])
+        for _ in range(number_of_bonds):
+            bond_mask = (self.df['residue_id'] == residue_id) & (self.df['pmb_type'] == "bond")
+            bond_rows = self.df.loc[bond_mask]
+            row=bond_rows.loc[[bond_rows.index[0]]]
+            self._clean_ids_in_df_row(row=row)
+
 
     def determine_reservoir_concentrations(self, pH_res, c_salt_res, activity_coefficient_monovalent_pair, max_number_sc_runs=200):
         """

--- a/samples/Beyer2024/peptide.py
+++ b/samples/Beyer2024/peptide.py
@@ -152,7 +152,7 @@ espresso_system.cell_system.skin=0.4
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
-pmb.create_pmb_object(name=sequence,
+pmb.create_molecule(name=sequence,
                     number_of_objects= N_peptide_chains,
                     espresso_system=espresso_system)
 

--- a/samples/Beyer2024/peptide.py
+++ b/samples/Beyer2024/peptide.py
@@ -153,7 +153,7 @@ pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
 pmb.create_molecule(name=sequence,
-                    number_of_objects= N_peptide_chains,
+                    number_of_molecules=N_peptide_chains,
                     espresso_system=espresso_system)
 
 # Create counterions for the peptide chains

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -181,9 +181,9 @@ if verbose:
     print("Added bonds")
 
 # Create molecules and ions in the espresso system
-pmb.create_pmb_object(name=polyacid_name, 
-                      number_of_objects=N_chains, 
-                      espresso_system=espresso_system)
+pmb.create_molecule(name=polyacid_name, 
+                    number_of_objects=N_chains, 
+                    espresso_system=espresso_system)
 pmb.create_counterions(object_name=polyacid_name, 
                        cation_name=proton_name, 
                        anion_name=hydroxide_name, 

--- a/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
+++ b/samples/Beyer2024/weak_polyelectrolyte_dialysis.py
@@ -182,7 +182,7 @@ if verbose:
 
 # Create molecules and ions in the espresso system
 pmb.create_molecule(name=polyacid_name, 
-                    number_of_objects=N_chains, 
+                    number_of_molecules=N_chains, 
                     espresso_system=espresso_system)
 pmb.create_counterions(object_name=polyacid_name, 
                        cation_name=proton_name, 

--- a/samples/branched_polyampholyte.py
+++ b/samples/branched_polyampholyte.py
@@ -158,10 +158,10 @@ espresso_system.cell_system.skin=0.4
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
-pmb.create_pmb_object(name="polyampholyte", 
-                      number_of_objects=N_polyampholyte_chains,
-                      espresso_system=espresso_system, 
-                      use_default_bond=True)
+pmb.create_molecule(name="polyampholyte", 
+                    number_of_objects=N_polyampholyte_chains,
+                    espresso_system=espresso_system, 
+                    use_default_bond=True)
 pmb.create_counterions(object_name="polyampholyte",
                        cation_name=cation_name,
                        anion_name=anion_name,

--- a/samples/branched_polyampholyte.py
+++ b/samples/branched_polyampholyte.py
@@ -159,7 +159,7 @@ pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
 pmb.create_molecule(name="polyampholyte", 
-                    number_of_objects=N_polyampholyte_chains,
+                    number_of_molecules=N_polyampholyte_chains,
                     espresso_system=espresso_system, 
                     use_default_bond=True)
 pmb.create_counterions(object_name="polyampholyte",

--- a/samples/peptide_cpH.py
+++ b/samples/peptide_cpH.py
@@ -134,7 +134,7 @@ pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
 pmb.create_molecule(name=peptide_name, 
-                    number_of_objects= N_peptide_chains,
+                    number_of_molecules=N_peptide_chains,
                     espresso_system=espresso_system, 
                     use_default_bond=True)
 # Create counterions for the peptide chains

--- a/samples/peptide_cpH.py
+++ b/samples/peptide_cpH.py
@@ -133,10 +133,10 @@ espresso_system.cell_system.skin=0.4
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
-pmb.create_pmb_object(name=peptide_name, 
-                        number_of_objects= N_peptide_chains,
-                        espresso_system=espresso_system, 
-                        use_default_bond=True)
+pmb.create_molecule(name=peptide_name, 
+                    number_of_objects= N_peptide_chains,
+                    espresso_system=espresso_system, 
+                    use_default_bond=True)
 # Create counterions for the peptide chains
 pmb.create_counterions(object_name=peptide_name,
                         cation_name=cation_name,

--- a/samples/peptide_mixture_grxmc_ideal.py
+++ b/samples/peptide_mixture_grxmc_ideal.py
@@ -173,14 +173,14 @@ espresso_system=espressomd.System (box_l = [L.to('reduced_length').magnitude]*3)
 pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
-pmb.create_pmb_object(name=peptide1, 
-                      number_of_objects= N_peptide1_chains,
-                      espresso_system=espresso_system, 
-                      use_default_bond=True)
-pmb.create_pmb_object(name=peptide2, 
-                      number_of_objects= N_peptide2_chains,
-                      espresso_system=espresso_system, 
-                      use_default_bond=True)
+pmb.create_molecule(name=peptide1, 
+                    number_of_objects= N_peptide1_chains,
+                    espresso_system=espresso_system, 
+                    use_default_bond=True)
+pmb.create_molecule(name=peptide2, 
+                    number_of_objects= N_peptide2_chains,
+                    espresso_system=espresso_system, 
+                    use_default_bond=True)
 
 if args.mode == 'standard':
     pmb.create_counterions(object_name=peptide1,

--- a/samples/peptide_mixture_grxmc_ideal.py
+++ b/samples/peptide_mixture_grxmc_ideal.py
@@ -174,11 +174,11 @@ pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
 # Create your molecules into the espresso system
 pmb.create_molecule(name=peptide1, 
-                    number_of_objects= N_peptide1_chains,
+                    number_of_molecules=N_peptide1_chains,
                     espresso_system=espresso_system, 
                     use_default_bond=True)
 pmb.create_molecule(name=peptide2, 
-                    number_of_objects= N_peptide2_chains,
+                    number_of_molecules=N_peptide2_chains,
                     espresso_system=espresso_system, 
                     use_default_bond=True)
 

--- a/testsuite/cph_ideal_tests.py
+++ b/testsuite/cph_ideal_tests.py
@@ -16,14 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Functional tests for following sample scripts:
-# samples/peptide.py
-# samples/analyze_time_series.py
-# samples/plot_peptide.py
-# TODO:
-# samples/branch_polyampholyte.py
-# samples/plot_branch_polyampholyte.py
-
 import sys
 import pathlib
 import tempfile

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -429,7 +429,7 @@ np.testing.assert_equal(actual=len(pmb.df),
                         desired=starting_number_of_rows-6, 
                         verbose=True)
 # This should delete 4 particles (residue 1 is a R3 residue)
-# 5 lines should also be removed from pmb.df
+# 4 lines should also be removed from pmb.df
 # Residues do not have repeated entries (no line deleted)
 # 3 from the removed particles, (repeated entries)
 # and 1 from the removed bonds (repeated entry)

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -462,24 +462,22 @@ for residue_name in molecule_parameters["M2"]["residue_list"]:
     central_bead_pos = espresso_system.part.by_id(central_bead_id).pos
     central_bead_positions.append(central_bead_pos)
 
-if len(central_bead_positions) == len(molecule_parameters["M2"]["residue_list"]):
-    
-    backbone_direction_1 = central_bead_positions[1] - central_bead_positions[0]
-    backbone_direction_2 = central_bead_positions[2] - central_bead_positions[1]
-    backbone_direction_1 /= np.linalg.norm(backbone_direction_1)
-    backbone_direction_2 /= np.linalg.norm(backbone_direction_2)
-    np.testing.assert_almost_equal(
-        actual = backbone_direction_1,
-        desired = backbone_vector,
-        verbose = True)
-    np.testing.assert_almost_equal(
-        actual = backbone_direction_2,
-        desired = backbone_vector,
-        verbose = True)
+# Here one expects 3 central bead positions for residues R1, R2, and R3
+np.testing.assert_equal(len(central_bead_positions),len(molecule_parameters["M2"]["residue_list"]))
+   
+backbone_direction_1 = central_bead_positions[1] - central_bead_positions[0]
+backbone_direction_2 = central_bead_positions[2] - central_bead_positions[1]
+backbone_direction_1 /= np.linalg.norm(backbone_direction_1)
+backbone_direction_2 /= np.linalg.norm(backbone_direction_2)
+np.testing.assert_almost_equal(
+    actual = backbone_direction_1,
+    desired = backbone_vector,
+    verbose = True)
+np.testing.assert_almost_equal(
+    actual = backbone_direction_2,
+    desired = backbone_vector,
+    verbose = True)
 
-else:
-
-    raise ValueError("Expected 3 central bead positions for residues R1, R2, and R3")        
 
 print("*** Unit test passed ***")
 

--- a/testsuite/define_and_create_molecules_unit_tests.py
+++ b/testsuite/define_and_create_molecules_unit_tests.py
@@ -19,6 +19,7 @@
 # Import pyMBE and other libraries
 import pyMBE
 import numpy as np
+import pandas as pd
 import espressomd
 
 # Create an instance of pyMBE library
@@ -192,6 +193,63 @@ input_parameters={"name": "R2",
 np.testing.assert_raises(ValueError, pmb.create_particle, **input_parameters)
 print("*** Unit test passed ***")
 
+# Unit tests for delete particle
+print("*** Unit test: check that delete_particle deletes the particle and cleans pmb.df  ***")
+starting_number_of_particles=len(espresso_system.part.all())
+starting_number_of_rows=len(pmb.df)
+# This should delete one particle and one row from the df because there are repeated entries of that type of particle
+pmb.delete_particle_in_system(particle_id=0,
+                              espresso_system=espresso_system)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                        desired=starting_number_of_particles-1, 
+                        verbose=True)
+np.testing.assert_equal(actual=len(pmb.df), 
+                        desired=starting_number_of_rows-1, 
+                        verbose=True)
+# This should delete one particle but not delete any row because it is the last entry of that type of particle
+# instead, the particle id should be cleared
+pmb.delete_particle_in_system(particle_id=1,
+                              espresso_system=espresso_system)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                        desired=starting_number_of_particles-2, 
+                        verbose=True)
+np.testing.assert_equal(actual=len(pmb.df), 
+                        desired=starting_number_of_rows-1, 
+                        verbose=True)
+
+def check_empty_columns(name_to_check):
+    empty_columns=['particle_id',
+                'particle_id2', 
+                'residue_id', 
+                'molecule_id']
+    for column in empty_columns:
+        assert pd.isna(pmb.df.loc[pmb.df['name'] == name_to_check][column]).all()
+
+check_empty_columns(name_to_check="S1")
+non_empty_columns=['name',
+                  'pmb_type',
+                  'sigma',
+                  'offset']
+for column in non_empty_columns:
+    assert pd.notna(pmb.df.loc[pmb.df['name'] == "S1"][column]).all()
+
+non_empty_columns=['label',
+                  'z',
+                  'es_type']
+for column in non_empty_columns:
+    assert pd.notna(pmb.df.loc[pmb.df['name'] == "S1"]["state_one"][column]).all()
+
+
+# test the sanity check
+input_parameters={"particle_id":0,
+                  "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, 
+                         pmb.delete_particle_in_system, 
+                         **input_parameters)
+# Create the particle back for the rest of the test
+pmb.create_particle(name="S1",
+                    espresso_system=espresso_system,
+                    number_of_particles=2)
 print("*** Unit test: check that create_residue() creates a simple residue into the espresso_system with the properties defined in pmb.df  ***")
 
 bond_type = 'harmonic'
@@ -353,6 +411,72 @@ np.testing.assert_equal(actual=len(espresso_system.part.all()),
                         desired=starting_number_of_particles, 
                         verbose=True)
 
+# Tests for delete_residue
+print("*** Unit test: check that delete_residue deletes the particle and cleans pmb.df  ***")
+# This should delete 3 particles (residue 0 is a R2 residue)
+# 6 lines should also be removed from pmb.df
+# One  because R2 has a repeated entry
+# 3 from the removed particles, (repeated entries)
+# and 2 from the removed bonds (repeated entries)
+starting_number_of_particles=len(espresso_system.part.all())
+starting_number_of_rows=len(pmb.df)
+pmb.delete_residue_in_system(residue_id=0,
+                             espresso_system=espresso_system)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                        desired=starting_number_of_particles-3, 
+                        verbose=True)
+np.testing.assert_equal(actual=len(pmb.df), 
+                        desired=starting_number_of_rows-6, 
+                        verbose=True)
+# This should delete 4 particles (residue 1 is a R3 residue)
+# 5 lines should also be removed from pmb.df
+# Residues do not have repeated entries (no line deleted)
+# 3 from the removed particles, (repeated entries)
+# and 1 from the removed bonds (repeated entry)
+starting_number_of_particles=len(espresso_system.part.all())
+starting_number_of_rows=len(pmb.df)
+pmb.delete_residue_in_system(residue_id=1,
+                             espresso_system=espresso_system)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                        desired=starting_number_of_particles-4, 
+                        verbose=True)
+np.testing.assert_equal(actual=len(pmb.df), 
+                        desired=starting_number_of_rows-4, 
+                        verbose=True)
+check_empty_columns(name_to_check="R2")
+check_empty_columns(name_to_check="R3")
+check_empty_columns(name_to_check="default")
+non_empty_columns=['name',
+                  'pmb_type',
+                  'central_bead',
+                  'side_chains']
+for res_name in ["R2","R3"]:
+    for column in non_empty_columns:
+        assert pd.notna(pmb.df.loc[pmb.df['name'] == res_name][column]).all()
+
+non_empty_columns=['name',
+                  'l0',
+                  'parameters_of_the_potential',
+                  'bond_object']
+
+for column in non_empty_columns:
+    assert pd.notna(pmb.df.loc[pmb.df['name'] == "default"][column]).all()
+
+input_parameters={"residue_id":0,
+                  "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, 
+                         pmb.delete_residue_in_system, 
+                         **input_parameters)
+# Create back the residues for the rest of the test
+pmb.create_residue(name="R2",
+                    espresso_system=espresso_system,
+                    central_bead_position=central_bead_position,
+                    backbone_vector=backbone_vector,
+                    use_default_bond=True)
+pmb.create_residue(name="R3",
+                    espresso_system=espresso_system,
+                    use_default_bond=True)
+print("*** Unit test passed ***")
 # Additional unit tests for define_molecule are in create_molecule_position_test
 print("*** Unit test: check that create_molecule() creates a simple molecule into the espresso_system with the properties defined in pmb.df  ***")
 
@@ -560,3 +684,60 @@ np.testing.assert_equal(actual=pmb.get_radius_map(dimensionless=False)[0].dimens
 
 print("*** Unit test passed ***")
 
+# Tests for delete_residue
+print("*** Unit test: check that delete_molecule deletes the particle and cleans pmb.df  ***")
+# This should delete 8 particles (molecule 0 is a M2 molecule)
+# 20 lines should also be removed from pmb.df
+# 1  because M2 has a repeated entry
+# 3 from the removed residues (repeated entries)
+# 8 from the removed particles, (repeated entries)
+# and 8 from the removed bonds (repeated entries)
+starting_number_of_particles=len(espresso_system.part.all())
+starting_number_of_rows=len(pmb.df)
+pmb.delete_molecule_in_system(molecule_id=0,
+                             espresso_system=espresso_system)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                        desired=starting_number_of_particles-8, 
+                        verbose=True)
+np.testing.assert_equal(actual=len(pmb.df), 
+                        desired=starting_number_of_rows-20, 
+                        verbose=True)
+# This should also delete 8 particles (molecule 1 is a M2 molecule)
+# 19 lines should also be removed from pmb.df
+# 0  because M2 is not repeated entry
+# 2 from the removed residues (repeated entries)
+# 8 from the removed particles, (repeated entries)
+# and 8 from the removed bonds (repeated entries)
+starting_number_of_particles=len(espresso_system.part.all())
+starting_number_of_rows=len(pmb.df)
+pmb.delete_molecule_in_system(molecule_id=1,
+                             espresso_system=espresso_system)
+np.testing.assert_equal(actual=len(espresso_system.part.all()), 
+                        desired=starting_number_of_particles-8, 
+                        verbose=True)
+np.testing.assert_equal(actual=len(pmb.df), 
+                        desired=starting_number_of_rows-18, 
+                        verbose=True)
+check_empty_columns(name_to_check="M2")
+non_empty_columns=['name',
+                  'pmb_type',
+                  'residue_list']
+
+for column in non_empty_columns:
+    assert pd.notna(pmb.df.loc[pmb.df['name'] == "M2"][column]).all()
+
+non_empty_columns=['name',
+                  'l0',
+                  'parameters_of_the_potential',
+                  'bond_object']
+
+for column in non_empty_columns:
+    assert pd.notna(pmb.df.loc[pmb.df['name'] == "default"][column]).all()
+
+input_parameters={"molecule_id":0,
+                  "espresso_system":espresso_system}
+np.testing.assert_raises(ValueError, 
+                         pmb.delete_molecule_in_system, 
+                         **input_parameters)
+
+print("*** Unit test passed ***")

--- a/testsuite/generate_coordinates_tests.py
+++ b/testsuite/generate_coordinates_tests.py
@@ -30,13 +30,11 @@ def test_arrays_less_equal(arr1, arr2, rtol=1e-7, atol=1e-7):
     rtol (float): Relative tolerance.
     atol (float): Absolute tolerance.
     """
-    try:
-        # Ensure arr1 is less than or equal to arr2 within the given tolerances
-        np.testing.assert_array_less(arr1, arr2 + atol + np.abs(arr2) * rtol)
-        # For equality, use np.minimum to ensure each element in arr1 is not greater than the corresponding element in arr2
-        np.testing.assert_allclose(arr1, np.minimum(arr1, arr2), rtol=rtol, atol=atol)
-    except AssertionError as e:
-        print("Test failed:", e)
+    # Ensure arr1 is less than or equal to arr2 within the given tolerances
+    np.testing.assert_array_less(arr1, arr2 + atol + np.abs(arr2) * rtol)
+    # For equality, use np.minimum to ensure each element in arr1 is not greater than the corresponding element in arr2
+    np.testing.assert_allclose(arr1, np.minimum(arr1, arr2), rtol=rtol, atol=atol)
+
 
 
 print("*** generate_random_points_in_a_sphere unit tests ***")

--- a/testsuite/generate_perpendicular_vectors_test.py
+++ b/testsuite/generate_perpendicular_vectors_test.py
@@ -44,8 +44,9 @@ def check_if_different_perpendicular_vectors_are_generated(vector,magnitude,n=50
                                 verbose = True)
     # Check that the {n} perpendicular vectors are different
     for vector_pair in combinations(perpendicular_vectors, 2):
-        if np.array_equal(vector_pair[0],vector_pair[1]):
-            raise Exception(f"Error: pmb.generate_trial_perpendicular_vector two equal perpendicular vectors v1 = {vector_pair[0]} v2 = {vector_pair[1]}")
+        assert not np.array_equal(vector_pair[0], vector_pair[1]), \
+            f"Error: pmb.generate_trial_perpendicular_vector generated two equal perpendicular vectors v1   = {vector_pair[0]} v2 = {vector_pair[1]}"
+        
     # Check that the perpendicular vectors have the same magnitude as the input magnitude
     for pvector in perpendicular_vectors:
         np.testing.assert_almost_equal(actual = np.linalg.norm(pvector), 

--- a/testsuite/globular_protein_unit_tests.py
+++ b/testsuite/globular_protein_unit_tests.py
@@ -34,22 +34,12 @@ c_protein =  2e-4 * pmb.units.mol / pmb.units.L
 Box_V =  1. / (pmb.N_A*c_protein)
 Box_L = Box_V**(1./3.) 
 
-def custom_serializer(obj):
-    if isinstance(obj, Quantity):
-        return {"value": obj.magnitude, "unit": str(obj.units)}  
-    raise TypeError(f"Type {type(obj)} not serializable")
-
 def custom_deserializer(dct):
     if "value" in dct and "unit" in dct:
         return ureg.Quantity(dct["value"], dct["unit"])  
     return dct  
 
-mode = "test"
 protein_pdb = '1f6s'
-valid_modes = ["save","test"]
-
-if mode not in valid_modes:
-    raise ValueError(f"mode {mode} not supported, valid modes are {valid_modes}")
 
 print("*** Unit test: check that read_protein_vtf_in_df() loads the protein topology correctly ***")
 
@@ -57,13 +47,9 @@ path_to_parfile = pathlib.Path(__file__).parent / "tests_data" / "protein_topolo
 path_to_cg=pmb.root / "parameters" / "globular_proteins" / f"{protein_pdb}.vtf"
 topology_dict = pmb.read_protein_vtf_in_df (filename=path_to_cg)
 
-if mode == "save":
-    with open (path_to_parfile, "w") as output:
-        json.dump(topology_dict, output,default=custom_serializer)
-    sys.exit()
-elif mode == "test":
-    with open (path_to_parfile, "r") as file:
-        load_json = json.load(file,object_hook=custom_deserializer)
+
+with open (path_to_parfile, "r") as file:
+    load_json = json.load(file,object_hook=custom_deserializer)
 
 np.testing.assert_equal(actual= topology_dict, 
                         desired= load_json,
@@ -91,13 +77,6 @@ for aminoacid in topology_dict.keys():
     
     if residue_name not in ['CA', 'n', 'c','Ca']:
         clean_sequence.append(residue_name)
-
-    
-    for index in pmb.df[pmb.df['name']==residue_name].index:
-        if residue_name not in sequence:           
-            np.testing.assert_equal(actual=str(pmb.df.loc[index, "pmb_type"].values[0]), 
-                                desired="particle", 
-                                verbose=True)
 
 residue_list = pmb.define_AA_residues(sequence= clean_sequence,
                                       model = protein_model)

--- a/testsuite/globular_protein_unit_tests.py
+++ b/testsuite/globular_protein_unit_tests.py
@@ -15,14 +15,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import sys
 import numpy as np 
 import espressomd
 import pyMBE
 import re
 import json
 import pathlib
-from pint import UnitRegistry, Quantity
+from pint import UnitRegistry
 
 ureg = UnitRegistry()
 

--- a/testsuite/lattice_builder.py
+++ b/testsuite/lattice_builder.py
@@ -182,7 +182,6 @@ class Test(ut.TestCase):
             np.testing.assert_equal(actual = lattice.get_monomer_color(label),desired = color, verbose=True)
             np.testing.assert_equal(actual = lattice.get_monomer_color_index(label),desired = index, verbose=True)
 
-
         # Test invalid operations
         with self.assertRaisesRegex(RuntimeError, "monomer 'unknown' has no associated color in the colormap"):
             lattice.get_monomer_color("unknown")
@@ -207,6 +206,14 @@ class Test(ut.TestCase):
         lattice.draw_simulation_box(ax)
         ax.legend()
         plt.close(fig)
+
+        # Test edge case with strict mode deactivated
+        diamond_test = pyMBE.lib.lattice.DiamondLattice(mpc, bond_l)
+        lattice_test = pmb.initialize_lattice_builder(diamond_test)
+        lattice_test.strict = False
+        key, reverse = lattice_test._get_node_vector_pair("[1 1 1]", "[3 3 1]")
+        assert not reverse, "Expected reverse to be False in non-strict mode"
+        np.testing.assert_equal(actual=key, desired=(1,5))
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/lattice_builder.py
+++ b/testsuite/lattice_builder.py
@@ -110,12 +110,22 @@ class Test(ut.TestCase):
         assert len(lattice.chains) ==  0
 
         # this function need some work
+        lattice.set_chain(node_start="[0 0 0]", node_end="[1 1 1]",
+                  sequence=sequence)
+        np.testing.assert_equal(actual = lattice.get_chain("[0 0 0]", "[1 1 1]"), desired = sequence, verbose=True)
+        lattice.set_chain(node_start="[1 1 1]", node_end="[0 0 0]",
+                  sequence=sequence)
+        np.testing.assert_equal(actual = lattice.get_chain("[1 1 1]", "[0 0 0]"), desired = sequence, verbose=True)
+        np.testing.assert_raises(RuntimeError, lattice.get_chain, "[1 1 1]", "[2 2 0]")
         lattice.add_default_chains(mpc=2)
         assert len(lattice.chains) ==  len(diamond.connectivity)
 
         # define custom nodes
         assert lattice.get_node("[1 1 1]") == "default_linker"
         assert lattice.get_node("[0 0 0]") == "default_linker"
+        # Change default node type
+        lattice.set_node(node="[1 1 1]", residue=NodeType1)
+        np.testing.assert_equal(actual = lattice.get_node("[1 1 1]"), desired = NodeType1, verbose=True)
 
         pos_node1 = pmb.create_hydrogel_node("[1 1 1]", NodeType1, espresso_system=espresso_system)
         np.testing.assert_equal(actual = lattice.get_node("[1 1 1]"), desired = NodeType1, verbose=True)

--- a/testsuite/lj_tests.py
+++ b/testsuite/lj_tests.py
@@ -203,14 +203,16 @@ lj_labels=pmb.filter_df("LennardJones")["name"].values
 # Particle C has sigma = 0 (ideally behaving particle)
 
 for label in lj_labels:
-    if "C" in label:
-        raise Exception("*** Unit Test failed ***")
+    assert "C" not in label, \
+        f"Error: pmb.setup_lj_interactions() set up LJ interaction for ideal particle with label {label}"
 
 print("*** Unit test passed ***")
 
 print("*** Unit test: test that get_lj_parameters() rasie the ValueError when the combination rule is not Loretz-Berthelot ***")
 
-input_params = {"particle_name1":"A", "particle_name2":"B", "combining_rule":"Geometric"}
+input_params = {"particle_name1":"A", 
+                "particle_name2":"B", 
+                "combining_rule":"Geometric"}
 np.testing.assert_raises(ValueError, pmb.get_lj_parameters, **input_params)
 
 print("*** All unit tests passed ***")

--- a/testsuite/parameter_test.py
+++ b/testsuite/parameter_test.py
@@ -20,10 +20,6 @@ import pathlib
 import pyMBE
 import pandas as pd
 import numpy as np
-version = pd.__version__.split(".")
-# This feature was introduced in Pandasv2.2.0
-if int(version[0]) >= 2 and int(version[1]) >= 2:
-    pd.set_option('future.no_silent_downcasting', True)
 
 pmb = pyMBE.pymbe_library(seed=42)
 

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -20,7 +20,14 @@ import tempfile
 import espressomd
 import pandas as pd
 import numpy as np
+import logging
+import io
 
+# Create an in-memory log stream
+log_stream = io.StringIO()
+logging.basicConfig(level=logging.INFO, 
+                    format="%(levelname)s: %(message)s",
+                    handlers=[logging.StreamHandler(log_stream)])
 # Create an instance of pyMBE library
 import pyMBE
 pmb = pyMBE.pymbe_library(seed=42)
@@ -157,4 +164,9 @@ read_df = read_df.replace({pd.NA: np.nan})
 pd.testing.assert_frame_equal(stored_df, 
                                 read_df,
                                 rtol=1e-5)
+print("*** Unit test passed***")
+
+# Test that copy_df_entry raises an error if one provides a non-valid column name
+print("*** Unit test: check that copy_df_entry raises an error if the entry does not exist ***")
+np.testing.assert_raises(ValueError, pmb.copy_df_entry, name='test', column_name='non_existing_column',number_of_copies=1)
 print("*** Unit test passed***")

--- a/testsuite/read-write-df_test.py
+++ b/testsuite/read-write-df_test.py
@@ -21,11 +21,6 @@ import espressomd
 import pandas as pd
 import numpy as np
 
-version = pd.__version__.split(".")
-# This feature was introduced in Pandasv2.2.0
-if int(version[0]) >= 2 and int(version[1]) >= 2:
-    pd.set_option('future.no_silent_downcasting', True)
-
 # Create an instance of pyMBE library
 import pyMBE
 pmb = pyMBE.pymbe_library(seed=42)

--- a/testsuite/seed_test.py
+++ b/testsuite/seed_test.py
@@ -19,7 +19,14 @@
 import numpy as np 
 import espressomd
 import pyMBE
+import logging
+import io
 
+# Create an in-memory log stream
+log_stream = io.StringIO()
+logging.basicConfig(level=logging.INFO, 
+                    format="%(levelname)s: %(message)s",
+                    handlers=[logging.StreamHandler(log_stream)])
 espresso_system = espressomd.System(box_l = [100]*3)
 
 def build_peptide_in_espresso(seed):
@@ -40,7 +47,9 @@ def build_peptide_in_espresso(seed):
 
     # Defines the peptide in the pyMBE data frame
     peptide_name = 'generic_peptide'
-    pmb.define_peptide(name=peptide_name, sequence=sequence, model=model)
+    pmb.define_peptide(name=peptide_name, 
+                       sequence=sequence, 
+                       model=model)
 
     # Bond parameters
     generic_bond_length=0.4 * pmb.units.nm
@@ -56,7 +65,10 @@ def build_peptide_in_espresso(seed):
     pmb.add_bonds_to_espresso(espresso_system=espresso_system)
 
     # Create molecule in the espresso system
-    pmb.create_pmb_object(name=peptide_name, number_of_objects=1, espresso_system=espresso_system, use_default_bond=True)
+    pmb.create_molecule(name=peptide_name, 
+                        number_of_molecules=1, 
+                        espresso_system=espresso_system, 
+                        use_default_bond=True)
 
     # Extract positions of particles in the peptide
     positions = []

--- a/testsuite/setup_salt_ions_unit_tests.py
+++ b/testsuite/setup_salt_ions_unit_tests.py
@@ -67,7 +67,13 @@ def check_salt_concentration(espresso_system,cation_name,anion_name,c_salt,N_SAL
     np.testing.assert_equal(get_number_of_particles(espresso_system, type_map[cation_name]),N_SALT_ION_PAIRS*abs(charge_number_map[type_map[anion_name]]))
     np.testing.assert_equal(get_number_of_particles(espresso_system, type_map[anion_name]),N_SALT_ION_PAIRS*abs(charge_number_map[type_map[cation_name]]))
     np.testing.assert_almost_equal(c_salt_calculated.m_as("mol/L"), c_salt.m_as("mol/L"))
-    espresso_system.part.clear()
+    cation_ids = pmb.get_particle_id_map(object_name=cation_name)["all"]
+    anion_ids  = pmb.get_particle_id_map(object_name=anion_name)["all"]
+    for id in cation_ids+anion_ids:
+        pmb.delete_particle_in_system(particle_id=id,
+                                        espresso_system=espresso_system)
+
+
 print("*** Unit test: test that create_added_salt works for a 1:1 salt (NaCl-like). Should print the added salt concentration and number of ions ***")
 check_salt_concentration(espresso_system=espresso_system,
                         cation_name="Na",
@@ -106,7 +112,11 @@ c_salt_calculated = pmb.create_added_salt(espresso_system=espresso_system,
 np.testing.assert_equal(get_number_of_particles(espresso_system, type_map["Na"]),N_SALT_ION_PAIRS)
 np.testing.assert_equal(get_number_of_particles(espresso_system, type_map["Cl"]),N_SALT_ION_PAIRS)
 np.testing.assert_almost_equal(c_salt_calculated.m_as("reduced_length**-3"), c_salt_part.m_as("reduced_length**-3"))
-espresso_system.part.clear()
+cation_ids = pmb.get_particle_id_map(object_name="Na")["all"]
+anion_ids = pmb.get_particle_id_map(object_name="Cl")["all"]
+for id in cation_ids+anion_ids:
+    pmb.delete_particle_in_system(particle_id=id,
+                                    espresso_system=espresso_system)
 
 print("*** Unit test: check that create_added_salt raises a ValueError if one provides a cation_name of an object that has been defined with a non-positive charge ***")
 input_parameters={"cation_name":"Cl",
@@ -151,51 +161,49 @@ assert "Object with name 'X' is not defined in the DataFrame, no ions will be cr
 ### Unit tests for the counter ions:
 
 
-def setup_molecules():
-    pmb.define_particle(name='0P',
-                            z=0)
-    pmb.define_particle(name='+1P',
-                        z=+1)
-    pmb.define_particle(name='-1P',
-                        z=-1)
-    pmb.define_residue(
-        name = 'R1',
-        central_bead = '0P',
-        side_chains = ['+1P']
-        )
+pmb.define_particle(name='0P',
+                        z=0)
+pmb.define_particle(name='+1P',
+                    z=+1)
+pmb.define_particle(name='-1P',
+                    z=-1)
+pmb.define_residue(
+    name = 'R1',
+    central_bead = '0P',
+    side_chains = ['+1P']
+    )
 
-    pmb.define_residue(
-        name = 'R2',
-        central_bead = '0P',
-        side_chains = ['-1P']
-        )
+pmb.define_residue(
+    name = 'R2',
+    central_bead = '0P',
+    side_chains = ['-1P']
+    )
 
-    bond_type = 'harmonic'
-    generic_bond_length=0.4 * pmb.units.nm
-    generic_harmonic_constant = 400 * pmb.units('reduced_energy / reduced_length**2')
+bond_type = 'harmonic'
+generic_bond_length=0.4 * pmb.units.nm
+generic_harmonic_constant = 400 * pmb.units('reduced_energy / reduced_length**2')
 
-    harmonic_bond = {'r_0'    : generic_bond_length,
-                    'k'      : generic_harmonic_constant,
-                    }
+harmonic_bond = {'r_0'    : generic_bond_length,
+                'k'      : generic_harmonic_constant,
+                }
 
-    pmb.define_default_bond(bond_type = bond_type, 
-                            bond_parameters = harmonic_bond)
-    # Add all bonds to espresso system
-    pmb.add_bonds_to_espresso(espresso_system=espresso_system)
-    molecule_name = 'positive_polyampholyte'
-    pmb.define_molecule(name=molecule_name, 
-                        residue_list = ['R1']*3+['R2']*2)
+pmb.define_default_bond(bond_type = bond_type, 
+                        bond_parameters = harmonic_bond)
+# Add all bonds to espresso system
+pmb.add_bonds_to_espresso(espresso_system=espresso_system)
+molecule_name = 'positive_polyampholyte'
+pmb.define_molecule(name=molecule_name, 
+                    residue_list = ['R1']*3+['R2']*2)
 
-    molecule_name = 'isoelectric_polyampholyte'
-    pmb.define_molecule(name=molecule_name, 
-                        residue_list = ['R1']*3+['R2']*3)
+molecule_name = 'isoelectric_polyampholyte'
+pmb.define_molecule(name=molecule_name, 
+                    residue_list = ['R1']*3+['R2']*3)
 
-    molecule_name = 'negative_polyampholyte'
-    pmb.define_molecule(name=molecule_name, 
-                        residue_list = ['R1']*2+['R2']*3)
+molecule_name = 'negative_polyampholyte'
+pmb.define_molecule(name=molecule_name, 
+                    residue_list = ['R1']*2+['R2']*3)
 
 def test_counterions(molecule_name, cation_name, anion_name, espresso_system, expected_numbers):
-    setup_molecules()
     pmb.create_molecule(name=molecule_name,
                         number_of_molecules= 2,
                         espresso_system=espresso_system,
@@ -207,9 +215,15 @@ def test_counterions(molecule_name, cation_name, anion_name, espresso_system, ex
     espresso_system.setup_type_map(type_list=type_map.values())
     np.testing.assert_equal(get_number_of_particles(espresso_system, type_map[cation_name]),expected_numbers[cation_name])
     np.testing.assert_equal(get_number_of_particles(espresso_system, type_map[anion_name]),expected_numbers[anion_name])
-    pmb.destroy_pmb_object_in_system(espresso_system=espresso_system,
-                                    name=molecule_name)
-    espresso_system.part.clear()
+    molecule_ids = list(pmb.get_particle_id_map(object_name=molecule_name)["molecule_map"].keys())
+    for mol_id in molecule_ids:
+        pmb.delete_molecule_in_system(molecule_id=mol_id,
+                                        espresso_system=espresso_system)
+    cation_ids = pmb.get_particle_id_map(object_name=cation_name)["all"]
+    anion_ids  = pmb.get_particle_id_map(object_name=anion_name)["all"]
+    for id in cation_ids+anion_ids:
+        pmb.delete_particle_in_system(particle_id=id,
+                                        espresso_system=espresso_system)
 
 print("*** Unit test: check that create_counterions creates the right number of monovalent counter ions for a polyampholyte with positive net charge. Should print the number of ions. ***")
 
@@ -256,7 +270,6 @@ test_counterions(molecule_name='negative_polyampholyte',
 print("*** Unit test passed ***")
 
 print("*** Unit test: check that create_counterions raises a ValueError if the charge number of the cation is not divisible by the negative charge of the polyampholyte ***")
-setup_molecules()
 pmb.create_molecule(name='isoelectric_polyampholyte',
                         number_of_molecules= 1,
                         espresso_system=espresso_system,
@@ -268,14 +281,13 @@ input_parameters={"cation_name":"Ca",
 np.testing.assert_raises(ValueError, pmb.create_counterions, **input_parameters)
 print("*** Unit test passed ***")
 print("*** Unit test: check that create_counterions raises a ValueError if the charge number of the anion is not divisible by the positive charge of the polyampholyte ***")
-setup_molecules()
 input_parameters={"cation_name":"Na",
                     "anion_name":"SO4",
                     "object_name":'isoelectric_polyampholyte',
                    "espresso_system":espresso_system}
 np.testing.assert_raises(ValueError, pmb.create_counterions, **input_parameters)
-pmb.destroy_pmb_object_in_system(espresso_system=espresso_system,
-                                    name='isoelectric_polyampholyte')
+pmb.delete_molecule_in_system(espresso_system=espresso_system,
+                              molecule_id=0)
 
 print("*** Unit test passed ***")
 print("*** Unit test: check that no create_counterions does not create counterions for molecules with no charge")

--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -269,8 +269,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb.destroy_pmb_object_in_system(name = cation_name, \n",
-    "                                 espresso_system = espresso_system)"
+    "# First search for the ids of the particles to delete\n",
+    "particle_id_map = pmb.get_particle_id_map(object_name=cation_name)\n",
+    "for pid in particle_id_map[\"all\"]:\n",
+    "    pmb.delete_particle_in_system(particle_id=pid, \n",
+    "                                  espresso_system = espresso_system)"
    ]
   },
   {
@@ -434,7 +437,7 @@
     "pmb.create_molecule(name = PDha_polymer, \n",
     "                    number_of_molecules = N_polymers,\n",
     "                    espresso_system = espresso_system, \n",
-    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3]) "
+    "                    list_of_first_residue_positions = [[Box_L.to('reduced_length').magnitude/2]*3]) "
    ]
   },
   {
@@ -486,8 +489,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb.destroy_pmb_object_in_system(name = PDha_polymer, \n",
-    "                                 espresso_system = espresso_system)\n",
+    "pmb.delete_molecule_in_system(molecule_id=0, \n",
+    "                              espresso_system = espresso_system)\n",
     "pmb.filter_df(pmb_type = 'particle')"
    ]
   },
@@ -655,7 +658,7 @@
     "pmb.create_molecule(name = PDAGA_polymer,\n",
     "                    number_of_molecules= N_polymers,\n",
     "                    espresso_system = espresso_system,\n",
-    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3])"
+    "                    list_of_first_residue_positions = [[Box_L.to('reduced_length').magnitude/2]*3])"
    ]
   },
   {
@@ -691,8 +694,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb.destroy_pmb_object_in_system(name = PDAGA_polymer, \n",
-    "                                 espresso_system = espresso_system)\n",
+    "# pyMBE always assigns a molecule id of 0 to the first created molecule\n",
+    "\n",
+    "pmb.delete_molecule_in_system(molecule_id=0,\n",
+    "                              espresso_system=espresso_system)\n",
     "pmb.filter_df(pmb_type = 'particle')"
    ]
   },
@@ -716,7 +721,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Defining each different bead of the PDha and PDAGA."
+    "Define the bond between the backbone particle of PDha and the backbone particle of PDAGA"
    ]
   },
   {
@@ -725,118 +730,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PDha_backbone_bead = 'BB-PDha'\n",
-    "PDha_carboxyl_bead = 'COOH-PDha'\n",
-    "PDha_amine_bead = 'NH3-PDha'\n",
-    "\n",
-    "pmb.define_particle(name = PDha_backbone_bead, \n",
-    "                    z = 0,\n",
-    "                    sigma = 0.4*pmb.units.nm,\n",
-    "                    epsilon = 1*pmb.units('reduced_energy'))\n",
-    "\n",
-    "pmb.define_particle(name = PDha_carboxyl_bead,\n",
-    "                    z = 0,\n",
-    "                    sigma = 0.5*pmb.units.nm,\n",
-    "                    epsilon = 1*pmb.units('reduced_energy'))\n",
-    "\n",
-    "pmb.define_particle(name = PDha_amine_bead,\n",
-    "                    z = 0,\n",
-    "                    sigma = 0.3*pmb.units.nm,\n",
-    "                    epsilon = 1*pmb.units('reduced_energy'))\n",
-    "\n",
-    "PDAGA_backbone_bead = 'BB-PDAGA'\n",
-    "PDAGA_cyclic_amine_bead = 'NH3-PDAGA'\n",
-    "PDAGA_alpha_carboxyl_bead = 'aCOOH-PDAGA'\n",
-    "PDAGA_beta_carboxyl_bead = 'bCOOH-PDAGA'\n",
-    "\n",
-    "\n",
-    "pmb.define_particle(name = PDAGA_backbone_bead,\n",
-    "                    z = 0,\n",
-    "                    sigma = 0.4*pmb.units.nm, \n",
-    "                    epsilon = 1*pmb.units('reduced_energy'))\n",
-    "\n",
-    "pmb.define_particle(name = PDAGA_cyclic_amine_bead,\n",
-    "                    z = 0, \n",
-    "                    sigma = 0.3*pmb.units.nm,\n",
-    "                    epsilon = 1*pmb.units('reduced_energy'))\n",
-    "\n",
-    "pmb.define_particle(name = PDAGA_alpha_carboxyl_bead,\n",
-    "                    z = 0,\n",
-    "                    sigma = 0.2*pmb.units.nm,\n",
-    "                    epsilon = 1*pmb.units('reduced_energy'))\n",
-    "\n",
-    "pmb.define_particle(name = PDAGA_beta_carboxyl_bead, \n",
-    "                    z = 0,\n",
-    "                    sigma = 0.4*pmb.units.nm,\n",
-    "                    epsilon = 1*pmb.units('reduced_energy'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Defining the different residues for the PDha and PDAGA."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bond_type = 'harmonic'\n",
-    "generic_bond_lenght=0.4 * pmb.units.nm\n",
-    "generic_harmonic_constant = 400 * pmb.units('reduced_energy / reduced_length**2')\n",
-    "\n",
-    "harmonic_bond = {'r_0'    : generic_bond_lenght,\n",
-    "                 'k'      : generic_harmonic_constant,\n",
-    "                 }\n",
-    "\n",
-    "######################################################################\n",
-    "################################# PDha ###############################\n",
-    "######################################################################\n",
-    "\n",
-    "PDha_residue = 'PDha_residue'\n",
-    "pmb.define_residue(name = PDha_residue, \n",
-    "                   central_bead =  PDha_backbone_bead ,\n",
-    "                   side_chains = [PDha_carboxyl_bead,PDha_amine_bead])\n",
-    "\n",
-    "\n",
-    "pmb.define_bond(bond_type = bond_type,\n",
-    "                bond_parameters = harmonic_bond,\n",
-    "                particle_pairs = [[PDha_backbone_bead, PDha_backbone_bead],\n",
-    "                                  [PDha_backbone_bead, PDha_carboxyl_bead],\n",
-    "                                  [PDha_backbone_bead, PDha_amine_bead]])\n",
-    "\n",
-    "######################################################################\n",
-    "################################ PDAGA ###############################\n",
-    "######################################################################\n",
-    "\n",
-    "PDAGA_monomer_residue = 'PDAGA_monomer_residue'\n",
-    "pmb.define_residue( name = PDAGA_monomer_residue,\n",
-    "                    central_bead = PDAGA_backbone_bead,\n",
-    "                    side_chains = [PDAGA_side_chain_residue])\n",
-    "\n",
-    "PDAGA_side_chain_residue = 'PDAGA_side_chain_residue'\n",
-    "pmb.define_residue (name = PDAGA_side_chain_residue,\n",
-    "                    central_bead = PDAGA_cyclic_amine_bead,\n",
-    "                    side_chains = [PDAGA_alpha_carboxyl_bead,PDAGA_beta_carboxyl_bead])\n",
-    "\n",
-    "pmb.define_bond(bond_type = bond_type,\n",
-    "                bond_parameters = harmonic_bond,\n",
-    "                particle_pairs = [[PDAGA_backbone_bead, PDAGA_backbone_bead],\n",
-    "                                  [PDAGA_backbone_bead, PDAGA_cyclic_amine_bead],\n",
-    "                                  [PDAGA_alpha_carboxyl_bead, PDAGA_cyclic_amine_bead],\n",
-    "                                  [PDAGA_beta_carboxyl_bead, PDAGA_cyclic_amine_bead]])\n",
-    "\n",
-    "######################################################################\n",
-    "############################# PDha - PDAGA ###########################\n",
-    "######################################################################\n",
     "\n",
     "pmb.define_bond(bond_type = bond_type,\n",
     "                bond_parameters = harmonic_bond,\n",
     "                particle_pairs = [[PDha_backbone_bead, PDAGA_backbone_bead]])\n",
-    "\n",
     "pmb.add_bonds_to_espresso(espresso_system = espresso_system)"
    ]
   },
@@ -844,7 +741,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Defining the di-block polymer molecule"
+    "Define the di-block polymer molecule using Python list comprehension methods"
    ]
   },
   {
@@ -879,7 +776,7 @@
     "pmb.create_molecule(name = diblock_polymer,\n",
     "                    number_of_molecules= N_polymers,\n",
     "                    espresso_system = espresso_system,\n",
-    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3]) "
+    "                    list_of_first_residue_positions = [[Box_L.to('reduced_length').magnitude/2]*3]) "
    ]
   },
   {
@@ -915,8 +812,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb.destroy_pmb_object_in_system(name = diblock_polymer, \n",
-    "                     espresso_system = espresso_system)\n",
+    "pmb.delete_molecule_in_system(molecule_id=0, \n",
+    "                              espresso_system = espresso_system)\n",
     "pmb.filter_df(pmb_type = 'particle')"
    ]
   },
@@ -1134,7 +1031,7 @@
     "pmb.create_molecule(name = sequence,\n",
     "                    number_of_molecules=  N_peptide,\n",
     "                    espresso_system = espresso_system,\n",
-    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3])"
+    "                    list_of_first_residue_positions = [[Box_L.to('reduced_length').magnitude/2]*3])"
    ]
   },
   {
@@ -1170,7 +1067,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmb.destroy_pmb_object_in_system(name = sequence, \n",
+    "pmb.delete_molecule_in_system(molecule_id=0, \n",
     "                                 espresso_system = espresso_system)"
    ]
   },

--- a/tutorials/pyMBE_tutorial.ipynb
+++ b/tutorials/pyMBE_tutorial.ipynb
@@ -193,9 +193,9 @@
    "outputs": [],
    "source": [
     "N_cations = 20\n",
-    "pmb.create_pmb_object(name = cation_name,\n",
-    "                      number_of_objects = N_cations,\n",
-    "                      espresso_system = espresso_system)"
+    "pmb.create_particle(name = cation_name,\n",
+    "                    number_of_particles = N_cations,\n",
+    "                    espresso_system = espresso_system)"
    ]
   },
   {
@@ -431,10 +431,10 @@
    "source": [
     "N_polymers = 1\n",
     "\n",
-    "pmb.create_pmb_object(name = PDha_polymer, \n",
-    "                      number_of_objects = N_polymers,\n",
-    "                      espresso_system = espresso_system, \n",
-    "                      position = [[Box_L.to('reduced_length').magnitude/2]*3]) "
+    "pmb.create_molecule(name = PDha_polymer, \n",
+    "                    number_of_molecules = N_polymers,\n",
+    "                    espresso_system = espresso_system, \n",
+    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3]) "
    ]
   },
   {
@@ -652,10 +652,10 @@
    "source": [
     "N_polymers = 1\n",
     "\n",
-    "pmb.create_pmb_object(name = PDAGA_polymer,\n",
-    "                      number_of_objects = N_polymers,\n",
-    "                      espresso_system = espresso_system,\n",
-    "                      position = [[Box_L.to('reduced_length').magnitude/2]*3])"
+    "pmb.create_molecule(name = PDAGA_polymer,\n",
+    "                    number_of_molecules= N_polymers,\n",
+    "                    espresso_system = espresso_system,\n",
+    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3])"
    ]
   },
   {
@@ -876,10 +876,10 @@
    "source": [
     "N_polymers = 1\n",
     "\n",
-    "pmb.create_pmb_object(name = diblock_polymer,\n",
-    "                      number_of_objects = N_polymers,\n",
-    "                      espresso_system = espresso_system,\n",
-    "                      position = [[Box_L.to('reduced_length').magnitude/2]*3]) "
+    "pmb.create_molecule(name = diblock_polymer,\n",
+    "                    number_of_molecules= N_polymers,\n",
+    "                    espresso_system = espresso_system,\n",
+    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3]) "
    ]
   },
   {
@@ -1131,10 +1131,10 @@
     "                   sequence = sequence, \n",
     "                   model = model)\n",
     "\n",
-    "pmb.create_pmb_object(name = sequence,\n",
-    "                      number_of_objects = N_peptide,\n",
-    "                      espresso_system = espresso_system,\n",
-    "                      position = [[Box_L.to('reduced_length').magnitude/2]*3])"
+    "pmb.create_molecule(name = sequence,\n",
+    "                    number_of_molecules=  N_peptide,\n",
+    "                    espresso_system = espresso_system,\n",
+    "                    position = [[Box_L.to('reduced_length').magnitude/2]*3])"
    ]
   },
   {


### PR DESCRIPTION
Closes #58, with this PR we reach full effective coverage of pyMBE. The lines that show as uncovered in the coverage report are due to the two versions of espresso that we currently support and are in reality covered when the testsuite runs with the development version. This issue will be solved once we update our dependency to the newer release of Espresso.

### Added
- Case-specific methods to delete particles, residues and molecules in pyMBE: `delete_particle_in_system`, `delete_residue_in_system`, `delete_molecule_in_system`. 

### Removed
- `pmb.destroy_pmb_object` has been deprecated in favor of case-specific deletion methods. 
- `pmb.create_pmb_object` has been deprecated in favor of case-specific creation methods. 

