### PR TITLE
Update data to release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2024-10-02
+## [1.0.0] - 2025-10-02
 
 ### Changed
 - Parameter sets (pKa values and force field-related parameters) from previous work are now belong to the pyMBE package and are directly accesible from the root path of the package. For example, the path to the Lunkad2021 data set can be accessed as `pmb.root / "parameters" / "peptides" / "Lunkad2021.json"`. (#132)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -136,6 +136,6 @@ references:
     type: software
     version: 1.0.0
     title: pyMBE
-    date-released: "2024-10-02"
+    date-released: "2025-10-02"
     license:
     - GPL-3.0-or-later


### PR DESCRIPTION
Updates `Citation.cff` and `CHANGELOG.md` to include metadata of the current Zenodo release