### PR TITLE
Remove legacy virtual environment overrides

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -21,7 +21,7 @@ jobs:
           - version: "4.2.2"
             eessi: ESPResSo/4.2.2-foss-2023a
           - version: "5.0-dev"
-            eessi: ESPResSo/8aa60cecd56cdd10ab62042c567552f347374f36-foss-2023b
+            eessi: ESPResSo/dc87ede3f6c218bb71624460752bc8c26a271c33-foss-2023b
     name: ubuntu - ESPResSo ${{ matrix.espresso.version }}
     steps:
       - name: Setup EESSI
@@ -37,7 +37,9 @@ jobs:
             ${{ matrix.espresso.eessi }}
       - name: Run testsuite
         run: |
+          export NUM_PROC=$(nproc)
+          export OMP_PROC_BIND=false OMP_NUM_THREADS=1
           module restore pymbe
           source venv/bin/activate
-          make functional_tests -j4
+          make functional_tests -j${NUM_PROC}
         shell: bash

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -21,7 +21,7 @@ jobs:
             eessi: ESPResSo/4.2.2-foss-2023a
             upload_artifact: true
           - version: "5.0-dev"
-            eessi: ESPResSo/8aa60cecd56cdd10ab62042c567552f347374f36-foss-2023b
+            eessi: ESPResSo/dc87ede3f6c218bb71624460752bc8c26a271c33-foss-2023b
             upload_artifact: false
     name: ubuntu - ESPResSo ${{ matrix.espresso.version }}
     steps:
@@ -46,10 +46,12 @@ jobs:
             coverage==7.4.4
       - name: Run testsuite
         run: |
+          export NUM_PROC=$(nproc)
+          export OMP_PROC_BIND=false OMP_NUM_THREADS=1
           module restore pymbe
           source venv/bin/activate
           make pylint
-          make unit_tests -j4 COVERAGE=1
+          make unit_tests -j${NUM_PROC} COVERAGE=1
           make docs
           make coverage_xml
         shell: bash


### PR DESCRIPTION
By default, OpenMP applications use all CPU cores unless one exports environment variable `OMP_NUM_THREADS=1`, but doing so changes the behavior of Linux command `nproc` to return that variable value instead of the actual number of CPU cores. This can be confusing to users who aren't familiar with OpenMP parallelization. Most clusters will build ESPResSo 5.0 with OpenMP enabled for performance reasons. The latest version of ESPResSo automatically sets the number of OpenMP threads to 1 a few milliseconds after `import espressomd` is executed, if that environment variable wasn't set by the user. We therefore no longer have to alter environment variables in the user's Python environment.